### PR TITLE
Omit all fields in Image if empty.  Should only send when populated.

### DIFF
--- a/image.go
+++ b/image.go
@@ -25,17 +25,17 @@ type ImageServiceOp struct {
 
 // Image represents a Shopify product's image.
 type Image struct {
-	ID         int        `json:"id"`
-	ProductID  int        `json:"product_id"`
-	Position   int        `json:"position"`
-	CreatedAt  *time.Time `json:"created_at"`
-	UpdatedAt  *time.Time `json:"updated_at"`
-	Width      int        `json:"width"`
-	Height     int        `json:"height"`
+	ID         int        `json:"id,omitempty"`
+	ProductID  int        `json:"product_id,omitempty"`
+	Position   int        `json:"position,omitempty"`
+	CreatedAt  *time.Time `json:"created_at,omitempty"`
+	UpdatedAt  *time.Time `json:"updated_at,omitempty"`
+	Width      int        `json:"width,omitempty"`
+	Height     int        `json:"height,omitempty"`
 	Src        string     `json:"src,omitempty"`
 	Attachment string     `json:"attachment,omitempty"`
 	Filename   string     `json:"filename,omitempty"`
-	VariantIds []int      `json:"variant_ids"`
+	VariantIds []int      `json:"variant_ids,omitempty"`
 }
 
 // ImageResource represents the result form the products/X/images/Y.json endpoint


### PR DESCRIPTION
Without this the "Position" field was always set to 0, inserting the image at the beginning.  When omitted it is appended at the end.   You can set the Position explicitly to 1 to set it as the first image.  Same with other fields, they don't make sense to send on creation, or when updating.

Probably for most APIs there is little difference sending empty values.  The problem here is the "Position", which the empty value has a meaning to shopify (i.e. insert it at start).     For me, just flagging Position as omit if empty would be ok ... but the better is probably to set them all.

@andrewhoff regarding your [comment](https://github.com/getconversio/go-shopify/pull/116#issuecomment-419929844), I took a look at some of the test and wasn't sure what test would be appropriate here.  The existing image test pass.   The failure mode would be if shopify expects these fields to always be populated (which they don't).    

If you have a suggestion, I'd be happy to implement it.