### PR TITLE
Add NewClient method to App struct

### DIFF
--- a/goshopify.go
+++ b/goshopify.go
@@ -165,6 +165,14 @@ func (c *Client) NewRequest(method, urlStr string, body, options interface{}) (*
 	return req, nil
 }
 
+// NewClient returns a new Shopify API client with an already authenticated shopname and
+// token. The shopName parameter is the shop's myshopify domain,
+// e.g. "theshop.myshopify.com", or simply "theshop"
+// a.NewClient(shopName, token) is equivalent to NewClient(a, shopName, token)
+func (a App) NewClient(shopName, token string) *Client {
+	return NewClient(a, shopName, token)
+}
+
 // Returns a new Shopify API client with an already authenticated shopname and
 // token. The shopName parameter is the shop's myshopify domain,
 // e.g. "theshop.myshopify.com", or simply "theshop"

--- a/goshopify_test.go
+++ b/goshopify_test.go
@@ -72,6 +72,22 @@ func TestNewClientWithNoToken(t *testing.T) {
 	}
 }
 
+func TestAppNewClient(t *testing.T) {
+	testClient := app.NewClient("fooshop", "abcd")
+	expected := "https://fooshop.myshopify.com"
+	if testClient.baseURL.String() != expected {
+		t.Errorf("NewClient BaseURL = %v, expected %v", testClient.baseURL.String(), expected)
+	}
+}
+
+func TestAppNewClientWithNoToken(t *testing.T) {
+	testClient := app.NewClient("fooshop", "")
+	expected := "https://fooshop.myshopify.com"
+	if testClient.baseURL.String() != expected {
+		t.Errorf("NewClient BaseURL = %v, expected %v", testClient.baseURL.String(), expected)
+	}
+}
+
 func TestNewRequest(t *testing.T) {
 	testClient := NewClient(app, "fooshop", "abcd")
 


### PR DESCRIPTION
* Add func `(a *App) NewClient(string, string) *Client` that calls the global `NewClient(*App, string, string) *Client` function. This was done to make components that create on-demand clients easier to unit test as it lets us define an interface for the shopify app and create a mock.