### PR TITLE
Add options to list customer orders

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -21,7 +21,7 @@ type CustomerService interface {
 	Create(Customer) (*Customer, error)
 	Update(Customer) (*Customer, error)
 	Delete(int) error
-	ListOrders(int) ([]Order, error)
+	ListOrders(int, interface{}) ([]Order, error)
 
 	// MetafieldsService used for Customer resource to communicate with Metafields resource
 	MetafieldsService
@@ -168,9 +168,9 @@ func (s *CustomerServiceOp) DeleteMetafield(customerID int, metafieldID int) err
 }
 
 // ListOrders retrieves all orders from a customer
-func (s *CustomerServiceOp) ListOrders(customerID int) ([]Order, error) {
+func (s *CustomerServiceOp) ListOrders(customerID int, options interface{}) ([]Order, error) {
 	path := fmt.Sprintf("%s/%d/orders.json", customersBasePath, customerID)
 	resource := new(OrdersResource)
-	err := s.client.Get(path, resource, nil)
+	err := s.client.Get(path, resource, options)
 	return resource.Orders, err
 }

--- a/customer_test.go
+++ b/customer_test.go
@@ -418,9 +418,25 @@ func TestCustomerListOrders(t *testing.T) {
 	httpmock.RegisterResponder(
 		"GET",
 		"https://fooshop.myshopify.com/admin/customers/1/orders.json",
+		httpmock.NewStringResponder(200, "{\"orders\":[]}"),
+	)
+	httpmock.RegisterResponder(
+		"GET",
+		"https://fooshop.myshopify.com/admin/customers/1/orders.json?status=any",
 		httpmock.NewBytesResponder(200, loadFixture("orders.json")),
 	)
-	orders, err := client.Customer.ListOrders(1)
+
+	orders, err := client.Customer.ListOrders(1, nil)
+	if err != nil {
+		t.Errorf("Customer.ListOrders returned error: %v", err)
+	}
+
+	// Check that orders were parsed
+	if len(orders) != 0 {
+		t.Errorf("Customer.ListOrders got %v orders, expected: 1", len(orders))
+	}
+
+	orders, err = client.Customer.ListOrders(1, OrderListOptions{Status: "any"})
 	if err != nil {
 		t.Errorf("Customer.ListOrders returned error: %v", err)
 	}


### PR DESCRIPTION
* Makes a breaking change to a method just recently added. Missing from the Shopify API documentation was the fact that this endpoint appears to take the same arguments as GET /admin/orders.json. 
