### PR TITLE
Add primary location ID to Shop struct

### DIFF
--- a/shop.go
+++ b/shop.go
@@ -46,6 +46,7 @@ type Shop struct {
 	PlanDisplayName         string     `json:"plan_display_name"`
 	PasswordEnabled         bool       `json:"password_enabled"`
 	PrimaryLocale           string     `json:"primary_locale"`
+	PrimaryLocationId       int        `json:"primary_location_id"`
 	Timezone                string     `json:"timezone"`
 	IanaTimezone            string     `json:"iana_timezone"`
 	ForceSSL                bool       `json:"force_ssl"`


### PR DESCRIPTION
`primary_location_id` - is an undocumented shop property that is still pretty useful:

> "Primary_location_id" on the shop.json is a property that will always return the "location_id" of the 'Shipping Origin' which is a setting in the Shopify admin under shipping.  This is the address used to calculate the default shipping rates.
[Source](https://ecommerce.shopify.com/c/api-announcements/t/updated-deadline-aug-1st-deprecation-important-changes-to-productvariant-refund-and-fulfillment-apis-513771)

Shopify API libraries in other languages [use this property](https://github.com/MONEI/Shopify-api-node/blob/master/index.d.ts#L1802). And it is likely to be added to the doc soon \[[proof](https://ecommerce.shopify.com/c/shopify-apis-and-technology/t/api-documentation-issues-222215)\].
