### PR TITLE
Fix product image field for json omitempty

### DIFF
--- a/order.go
+++ b/order.go
@@ -104,7 +104,7 @@ type Order struct {
 	NoteAttributes        []NoteAttribute  `json:"note_attributes,omitempty"`
 	DiscountCodes         []DiscountCode   `json:"discount_codes,omitempty"`
 	LineItems             []LineItem       `json:"line_items,omitempty"`
-	ShippingLines         []ShippingLines  `json:"shipping_lines,omitempty"`
+	ShippingLines         []ShippingLine   `json:"shipping_lines,omitempty"`
 	Transactions          []Transaction    `json:"transactions,omitempty"`
 	AppID                 int              `json:"app_id,omitempty"`
 	CustomerLocale        string           `json:"customer_locale,omitempty"`
@@ -214,7 +214,7 @@ type PaymentDetails struct {
 	CreditCardCompany string `json:"credit_card_company,omitempty"`
 }
 
-type ShippingLines struct {
+type ShippingLine struct {
 	ID                            int              `json:"id,omitempty"`
 	Title                         string           `json:"title,omitempty"`
 	Price                         *decimal.Decimal `json:"price,omitempty"`

--- a/product.go
+++ b/product.go
@@ -44,7 +44,7 @@ type Product struct {
 	Tags                           string          `json:"tags,omitempty"`
 	Options                        []ProductOption `json:"options,omitempty"`
 	Variants                       []Variant       `json:"variants,omitempty"`
-	Image                          Image           `json:"image,omitempty"`
+	Image                          *Image          `json:"image,omitempty"`
 	Images                         []Image         `json:"images,omitempty"`
 	TemplateSuffix                 string          `json:"template_suffix,omitempty"`
 	MetafieldsGlobalTitleTag       string          `json:"metafields_global_title_tag,omitempty"`


### PR DESCRIPTION
Fix product image for json omitempty.
Because the response of product, the image should not be empty json string '{}' if the image is nil.
