### PR TITLE
int to int64 type conversion for ID fields

### DIFF
--- a/applicationcharge.go
+++ b/applicationcharge.go
@@ -26,7 +26,7 @@ type ApplicationChargeServiceOp struct {
 type ApplicationCharge struct {
 	ID                 int64            `json:"id"`
 	Name               string           `json:"name"`
-	APIClientID        int              `json:"api_client_id"`
+	APIClientID        int64              `json:"api_client_id"`
 	Price              *decimal.Decimal `json:"price"`
 	Status             string           `json:"status"`
 	ReturnURL          string           `json:"return_url"`

--- a/applicationcharge.go
+++ b/applicationcharge.go
@@ -14,7 +14,7 @@ const applicationChargesBasePath = "admin/application_charges"
 // See https://help.shopify.com/api/reference/billing/applicationcharge
 type ApplicationChargeService interface {
 	Create(ApplicationCharge) (*ApplicationCharge, error)
-	Get(int, interface{}) (*ApplicationCharge, error)
+	Get(int64, interface{}) (*ApplicationCharge, error)
 	List(interface{}) ([]ApplicationCharge, error)
 	Activate(ApplicationCharge) (*ApplicationCharge, error)
 }
@@ -24,7 +24,7 @@ type ApplicationChargeServiceOp struct {
 }
 
 type ApplicationCharge struct {
-	ID                 int              `json:"id"`
+	ID                 int64              `json:"id"`
 	Name               string           `json:"name"`
 	APIClientID        int              `json:"api_client_id"`
 	Price              *decimal.Decimal `json:"price"`
@@ -58,7 +58,7 @@ func (a ApplicationChargeServiceOp) Create(charge ApplicationCharge) (*Applicati
 }
 
 // Get gets individual application charge.
-func (a ApplicationChargeServiceOp) Get(chargeID int, options interface{}) (*ApplicationCharge, error) {
+func (a ApplicationChargeServiceOp) Get(chargeID int64, options interface{}) (*ApplicationCharge, error) {
 	path := fmt.Sprintf("%s/%d.json", applicationChargesBasePath, chargeID)
 	resource := &ApplicationChargeResource{}
 	return resource.Charge, a.client.Get(path, resource, options)

--- a/applicationcharge.go
+++ b/applicationcharge.go
@@ -24,7 +24,7 @@ type ApplicationChargeServiceOp struct {
 }
 
 type ApplicationCharge struct {
-	ID                 int64              `json:"id"`
+	ID                 int64            `json:"id"`
 	Name               string           `json:"name"`
 	APIClientID        int              `json:"api_client_id"`
 	Price              *decimal.Decimal `json:"price"`

--- a/applicationcharge_test.go
+++ b/applicationcharge_test.go
@@ -19,7 +19,7 @@ func applicationChargeTests(t *testing.T, charge ApplicationCharge) {
 	}{
 		{"ID", int64(1017262355), charge.ID},
 		{"Name", "Super Duper Expensive action", charge.Name},
-		{"APIClientID", 755357713, charge.APIClientID},
+		{"APIClientID", int64(755357713), charge.APIClientID},
 		{"Price", decimal.NewFromFloat(100.00).String(), charge.Price.String()},
 		{"Status", "pending", charge.Status},
 		{"ReturnURL", "http://super-duper.shopifyapps.com/", charge.ReturnURL},

--- a/applicationcharge_test.go
+++ b/applicationcharge_test.go
@@ -17,7 +17,7 @@ func applicationChargeTests(t *testing.T, charge ApplicationCharge) {
 		expected interface{}
 		actual   interface{}
 	}{
-		{"ID", 1017262355, charge.ID},
+		{"ID", int64(1017262355), charge.ID},
 		{"Name", "Super Duper Expensive action", charge.Name},
 		{"APIClientID", 755357713, charge.APIClientID},
 		{"Price", decimal.NewFromFloat(100.00).String(), charge.Price.String()},

--- a/asset.go
+++ b/asset.go
@@ -32,7 +32,7 @@ type Asset struct {
 	Size        int        `json:"size"`
 	SourceKey   string     `json:"source_key"`
 	Src         string     `json:"src"`
-	ThemeID     int64        `json:"theme_id"`
+	ThemeID     int64      `json:"theme_id"`
 	Value       string     `json:"value"`
 	CreatedAt   *time.Time `json:"created_at"`
 	UpdatedAt   *time.Time `json:"updated_at"`
@@ -50,7 +50,7 @@ type AssetsResource struct {
 
 type assetGetOptions struct {
 	Key     string `url:"asset[key]"`
-	ThemeID int64    `url:"theme_id"`
+	ThemeID int64  `url:"theme_id"`
 }
 
 // List the metadata for all assets in the given theme

--- a/asset.go
+++ b/asset.go
@@ -11,10 +11,10 @@ const assetsBasePath = "admin/themes"
 // of the Shopify API.
 // See: https://help.shopify.com/api/reference/asset
 type AssetService interface {
-	List(int, interface{}) ([]Asset, error)
-	Get(int, string) (*Asset, error)
-	Update(int, Asset) (*Asset, error)
-	Delete(int, string) error
+	List(int64, interface{}) ([]Asset, error)
+	Get(int64, string) (*Asset, error)
+	Update(int64, Asset) (*Asset, error)
+	Delete(int64, string) error
 }
 
 // AssetServiceOp handles communication with the asset related methods of
@@ -32,7 +32,7 @@ type Asset struct {
 	Size        int        `json:"size"`
 	SourceKey   string     `json:"source_key"`
 	Src         string     `json:"src"`
-	ThemeID     int        `json:"theme_id"`
+	ThemeID     int64        `json:"theme_id"`
 	Value       string     `json:"value"`
 	CreatedAt   *time.Time `json:"created_at"`
 	UpdatedAt   *time.Time `json:"updated_at"`
@@ -50,11 +50,11 @@ type AssetsResource struct {
 
 type assetGetOptions struct {
 	Key     string `url:"asset[key]"`
-	ThemeID int    `url:"theme_id"`
+	ThemeID int64    `url:"theme_id"`
 }
 
 // List the metadata for all assets in the given theme
-func (s *AssetServiceOp) List(themeID int, options interface{}) ([]Asset, error) {
+func (s *AssetServiceOp) List(themeID int64, options interface{}) ([]Asset, error) {
 	path := fmt.Sprintf("%s/%d/assets.json", assetsBasePath, themeID)
 	resource := new(AssetsResource)
 	err := s.client.Get(path, resource, options)
@@ -62,7 +62,7 @@ func (s *AssetServiceOp) List(themeID int, options interface{}) ([]Asset, error)
 }
 
 // Get an asset by key from the given theme
-func (s *AssetServiceOp) Get(themeID int, key string) (*Asset, error) {
+func (s *AssetServiceOp) Get(themeID int64, key string) (*Asset, error) {
 	path := fmt.Sprintf("%s/%d/assets.json", assetsBasePath, themeID)
 	options := assetGetOptions{
 		Key:     key,
@@ -74,7 +74,7 @@ func (s *AssetServiceOp) Get(themeID int, key string) (*Asset, error) {
 }
 
 // Update an asset
-func (s *AssetServiceOp) Update(themeID int, asset Asset) (*Asset, error) {
+func (s *AssetServiceOp) Update(themeID int64, asset Asset) (*Asset, error) {
 	path := fmt.Sprintf("%s/%d/assets.json", assetsBasePath, themeID)
 	wrappedData := AssetResource{Asset: &asset}
 	resource := new(AssetResource)
@@ -83,7 +83,7 @@ func (s *AssetServiceOp) Update(themeID int, asset Asset) (*Asset, error) {
 }
 
 // Delete an asset
-func (s *AssetServiceOp) Delete(themeID int, key string) error {
+func (s *AssetServiceOp) Delete(themeID int64, key string) error {
 	path := fmt.Sprintf("%s/%d/assets.json?asset[key]=%s", assetsBasePath, themeID, key)
 	return s.client.Delete(path)
 }

--- a/blog.go
+++ b/blog.go
@@ -13,10 +13,10 @@ const blogsBasePath = "admin/blogs"
 type BlogService interface {
 	List(interface{}) ([]Blog, error)
 	Count(interface{}) (int, error)
-	Get(int, interface{}) (*Blog, error)
+	Get(int64, interface{}) (*Blog, error)
 	Create(Blog) (*Blog, error)
 	Update(Blog) (*Blog, error)
-	Delete(int) error
+	Delete(int64) error
 }
 
 // BlogServiceOp handles communication with the blog related methods of
@@ -27,7 +27,7 @@ type BlogServiceOp struct {
 
 // Blog represents a Shopify blog
 type Blog struct {
-	ID                 int        `json:"id"`
+	ID                 int64        `json:"id"`
 	Title              string     `json:"title"`
 	Commentable        string     `json:"commentable"`
 	Feedburner         string     `json:"feedburner"`
@@ -65,7 +65,7 @@ func (s *BlogServiceOp) Count(options interface{}) (int, error) {
 }
 
 // Get single blog
-func (s *BlogServiceOp) Get(blogId int, options interface{}) (*Blog, error) {
+func (s *BlogServiceOp) Get(blogId int64, options interface{}) (*Blog, error) {
 	path := fmt.Sprintf("%s/%d.json", blogsBasePath, blogId)
 	resource := new(BlogResource)
 	err := s.client.Get(path, resource, options)
@@ -91,6 +91,6 @@ func (s *BlogServiceOp) Update(blog Blog) (*Blog, error) {
 }
 
 // Delete an blog
-func (s *BlogServiceOp) Delete(blogId int) error {
+func (s *BlogServiceOp) Delete(blogId int64) error {
 	return s.client.Delete(fmt.Sprintf("%s/%d.json", blogsBasePath, blogId))
 }

--- a/blog.go
+++ b/blog.go
@@ -27,7 +27,7 @@ type BlogServiceOp struct {
 
 // Blog represents a Shopify blog
 type Blog struct {
-	ID                 int64        `json:"id"`
+	ID                 int64      `json:"id"`
 	Title              string     `json:"title"`
 	Commentable        string     `json:"commentable"`
 	Feedburner         string     `json:"feedburner"`

--- a/blog_test.go
+++ b/blog_test.go
@@ -104,7 +104,7 @@ func TestBlogCreate(t *testing.T) {
 		t.Errorf("Blog.Create returned error: %v", err)
 	}
 
-	expectedInt := 241253187
+	expectedInt := int64(241253187)
 	if returnedBlog.ID != expectedInt {
 		t.Errorf("Blog.ID returned %+v, expected %+v", returnedBlog.ID, expectedInt)
 	}
@@ -134,7 +134,7 @@ func TestBlogUpdate(t *testing.T) {
 		t.Errorf("Blog.Update returned error: %v", err)
 	}
 
-	expectedInt := 241253187
+	expectedInt := int64(241253187)
 	if returnedBlog.ID != expectedInt {
 		t.Errorf("Blog.ID returned %+v, expected %+v", returnedBlog.ID, expectedInt)
 	}

--- a/collect.go
+++ b/collect.go
@@ -23,9 +23,9 @@ type CollectServiceOp struct {
 
 // Collect represents a Shopify collect
 type Collect struct {
-	ID           int64        `json:"id,omitempty"`
-	CollectionID int64        `json:"collection_id,omitempty"`
-	ProductID    int64        `json:"product_id,omitempty"`
+	ID           int64      `json:"id,omitempty"`
+	CollectionID int64      `json:"collection_id,omitempty"`
+	ProductID    int64      `json:"product_id,omitempty"`
 	Featured     bool       `json:"featured,omitempty"`
 	CreatedAt    *time.Time `json:"created_at,omitempty"`
 	UpdatedAt    *time.Time `json:"updated_at,omitempty"`

--- a/collect.go
+++ b/collect.go
@@ -23,9 +23,9 @@ type CollectServiceOp struct {
 
 // Collect represents a Shopify collect
 type Collect struct {
-	ID           int        `json:"id,omitempty"`
-	CollectionID int        `json:"collection_id,omitempty"`
-	ProductID    int        `json:"product_id,omitempty"`
+	ID           int64        `json:"id,omitempty"`
+	CollectionID int64        `json:"collection_id,omitempty"`
+	ProductID    int64        `json:"product_id,omitempty"`
 	Featured     bool       `json:"featured,omitempty"`
 	CreatedAt    *time.Time `json:"created_at,omitempty"`
 	UpdatedAt    *time.Time `json:"updated_at,omitempty"`

--- a/customcollection.go
+++ b/customcollection.go
@@ -31,7 +31,7 @@ type CustomCollectionServiceOp struct {
 
 // CustomCollection represents a Shopify custom collection.
 type CustomCollection struct {
-	ID             int64         `json:"id"`
+	ID             int64       `json:"id"`
 	Handle         string      `json:"handle"`
 	Title          string      `json:"title"`
 	UpdatedAt      *time.Time  `json:"updated_at"`

--- a/customcollection.go
+++ b/customcollection.go
@@ -14,10 +14,10 @@ const customCollectionsResourceName = "collections"
 type CustomCollectionService interface {
 	List(interface{}) ([]CustomCollection, error)
 	Count(interface{}) (int, error)
-	Get(int, interface{}) (*CustomCollection, error)
+	Get(int64, interface{}) (*CustomCollection, error)
 	Create(CustomCollection) (*CustomCollection, error)
 	Update(CustomCollection) (*CustomCollection, error)
-	Delete(int) error
+	Delete(int64) error
 
 	// MetafieldsService used for CustomCollection resource to communicate with Metafields resource
 	MetafieldsService
@@ -31,7 +31,7 @@ type CustomCollectionServiceOp struct {
 
 // CustomCollection represents a Shopify custom collection.
 type CustomCollection struct {
-	ID             int         `json:"id"`
+	ID             int64         `json:"id"`
 	Handle         string      `json:"handle"`
 	Title          string      `json:"title"`
 	UpdatedAt      *time.Time  `json:"updated_at"`
@@ -70,7 +70,7 @@ func (s *CustomCollectionServiceOp) Count(options interface{}) (int, error) {
 }
 
 // Get individual custom collection
-func (s *CustomCollectionServiceOp) Get(collectionID int, options interface{}) (*CustomCollection, error) {
+func (s *CustomCollectionServiceOp) Get(collectionID int64, options interface{}) (*CustomCollection, error) {
 	path := fmt.Sprintf("%s/%d.json", customCollectionsBasePath, collectionID)
 	resource := new(CustomCollectionResource)
 	err := s.client.Get(path, resource, options)
@@ -97,42 +97,42 @@ func (s *CustomCollectionServiceOp) Update(collection CustomCollection) (*Custom
 }
 
 // Delete an existing custom collection.
-func (s *CustomCollectionServiceOp) Delete(collectionID int) error {
+func (s *CustomCollectionServiceOp) Delete(collectionID int64) error {
 	return s.client.Delete(fmt.Sprintf("%s/%d.json", customCollectionsBasePath, collectionID))
 }
 
 // List metafields for a custom collection
-func (s *CustomCollectionServiceOp) ListMetafields(customCollectionID int, options interface{}) ([]Metafield, error) {
+func (s *CustomCollectionServiceOp) ListMetafields(customCollectionID int64, options interface{}) ([]Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: customCollectionsResourceName, resourceID: customCollectionID}
 	return metafieldService.List(options)
 }
 
 // Count metafields for a custom collection
-func (s *CustomCollectionServiceOp) CountMetafields(customCollectionID int, options interface{}) (int, error) {
+func (s *CustomCollectionServiceOp) CountMetafields(customCollectionID int64, options interface{}) (int, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: customCollectionsResourceName, resourceID: customCollectionID}
 	return metafieldService.Count(options)
 }
 
 // Get individual metafield for a custom collection
-func (s *CustomCollectionServiceOp) GetMetafield(customCollectionID int, metafieldID int, options interface{}) (*Metafield, error) {
+func (s *CustomCollectionServiceOp) GetMetafield(customCollectionID int64, metafieldID int64, options interface{}) (*Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: customCollectionsResourceName, resourceID: customCollectionID}
 	return metafieldService.Get(metafieldID, options)
 }
 
 // Create a new metafield for a custom collection
-func (s *CustomCollectionServiceOp) CreateMetafield(customCollectionID int, metafield Metafield) (*Metafield, error) {
+func (s *CustomCollectionServiceOp) CreateMetafield(customCollectionID int64, metafield Metafield) (*Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: customCollectionsResourceName, resourceID: customCollectionID}
 	return metafieldService.Create(metafield)
 }
 
 // Update an existing metafield for a custom collection
-func (s *CustomCollectionServiceOp) UpdateMetafield(customCollectionID int, metafield Metafield) (*Metafield, error) {
+func (s *CustomCollectionServiceOp) UpdateMetafield(customCollectionID int64, metafield Metafield) (*Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: customCollectionsResourceName, resourceID: customCollectionID}
 	return metafieldService.Update(metafield)
 }
 
 // // Delete an existing metafield for a custom collection
-func (s *CustomCollectionServiceOp) DeleteMetafield(customCollectionID int, metafieldID int) error {
+func (s *CustomCollectionServiceOp) DeleteMetafield(customCollectionID int64, metafieldID int64) error {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: customCollectionsResourceName, resourceID: customCollectionID}
 	return metafieldService.Delete(metafieldID)
 }

--- a/customcollection_test.go
+++ b/customcollection_test.go
@@ -16,7 +16,7 @@ func customCollectionTests(t *testing.T, collection CustomCollection) {
 		expected interface{}
 		actual   interface{}
 	}{
-		{"ID", 30497275952, collection.ID},
+		{"ID", int64(30497275952), collection.ID},
 		{"Handle", "macbooks", collection.Handle},
 		{"Title", "Macbooks", collection.Title},
 		{"BodyHTML", "Macbook Body", collection.BodyHTML},

--- a/customer.go
+++ b/customer.go
@@ -16,12 +16,12 @@ const customersResourceName = "customers"
 type CustomerService interface {
 	List(interface{}) ([]Customer, error)
 	Count(interface{}) (int, error)
-	Get(int, interface{}) (*Customer, error)
+	Get(int64, interface{}) (*Customer, error)
 	Search(interface{}) ([]Customer, error)
 	Create(Customer) (*Customer, error)
 	Update(Customer) (*Customer, error)
-	Delete(int) error
-	ListOrders(int, interface{}) ([]Order, error)
+	Delete(int64) error
+	ListOrders(int64, interface{}) ([]Order, error)
 	ListTags(interface{}) ([]string, error)
 
 	// MetafieldsService used for Customer resource to communicate with Metafields resource
@@ -36,7 +36,7 @@ type CustomerServiceOp struct {
 
 // Customer represents a Shopify customer
 type Customer struct {
-	ID                  int                `json:"id,omitempty"`
+	ID                  int64                `json:"id,omitempty"`
 	Email               string             `json:"email,omitempty"`
 	FirstName           string             `json:"first_name,omitempty"`
 	LastName            string             `json:"last_name,omitempty"`
@@ -49,7 +49,7 @@ type Customer struct {
 	TotalSpent          *decimal.Decimal   `json:"total_spent,omitempty"`
 	Phone               string             `json:"phone,omitempty"`
 	Tags                string             `json:"tags,omitempty"`
-	LastOrderId         int                `json:"last_order_id,omitempty"`
+	LastOrderId         int64                `json:"last_order_id,omitempty"`
 	LastOrderName       string             `json:"last_order_name,omitempty"`
 	AcceptsMarketing    bool               `json:"accepts_marketing,omitempty"`
 	DefaultAddress      *CustomerAddress   `json:"default_address,omitempty"`
@@ -98,7 +98,7 @@ func (s *CustomerServiceOp) Count(options interface{}) (int, error) {
 }
 
 // Get customer
-func (s *CustomerServiceOp) Get(customerID int, options interface{}) (*Customer, error) {
+func (s *CustomerServiceOp) Get(customerID int64, options interface{}) (*Customer, error) {
 	path := fmt.Sprintf("%s/%v.json", customersBasePath, customerID)
 	resource := new(CustomerResource)
 	err := s.client.Get(path, resource, options)
@@ -124,7 +124,7 @@ func (s *CustomerServiceOp) Update(customer Customer) (*Customer, error) {
 }
 
 // Delete an existing customer
-func (s *CustomerServiceOp) Delete(customerID int) error {
+func (s *CustomerServiceOp) Delete(customerID int64) error {
 	path := fmt.Sprintf("%s/%d.json", customersBasePath, customerID)
 	return s.client.Delete(path)
 }
@@ -138,43 +138,43 @@ func (s *CustomerServiceOp) Search(options interface{}) ([]Customer, error) {
 }
 
 // List metafields for a customer
-func (s *CustomerServiceOp) ListMetafields(customerID int, options interface{}) ([]Metafield, error) {
+func (s *CustomerServiceOp) ListMetafields(customerID int64, options interface{}) ([]Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: customersResourceName, resourceID: customerID}
 	return metafieldService.List(options)
 }
 
 // Count metafields for a customer
-func (s *CustomerServiceOp) CountMetafields(customerID int, options interface{}) (int, error) {
+func (s *CustomerServiceOp) CountMetafields(customerID int64, options interface{}) (int, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: customersResourceName, resourceID: customerID}
 	return metafieldService.Count(options)
 }
 
 // Get individual metafield for a customer
-func (s *CustomerServiceOp) GetMetafield(customerID int, metafieldID int, options interface{}) (*Metafield, error) {
+func (s *CustomerServiceOp) GetMetafield(customerID int64, metafieldID int64, options interface{}) (*Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: customersResourceName, resourceID: customerID}
 	return metafieldService.Get(metafieldID, options)
 }
 
 // Create a new metafield for a customer
-func (s *CustomerServiceOp) CreateMetafield(customerID int, metafield Metafield) (*Metafield, error) {
+func (s *CustomerServiceOp) CreateMetafield(customerID int64, metafield Metafield) (*Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: customersResourceName, resourceID: customerID}
 	return metafieldService.Create(metafield)
 }
 
 // Update an existing metafield for a customer
-func (s *CustomerServiceOp) UpdateMetafield(customerID int, metafield Metafield) (*Metafield, error) {
+func (s *CustomerServiceOp) UpdateMetafield(customerID int64, metafield Metafield) (*Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: customersResourceName, resourceID: customerID}
 	return metafieldService.Update(metafield)
 }
 
 // // Delete an existing metafield for a customer
-func (s *CustomerServiceOp) DeleteMetafield(customerID int, metafieldID int) error {
+func (s *CustomerServiceOp) DeleteMetafield(customerID int64, metafieldID int64) error {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: customersResourceName, resourceID: customerID}
 	return metafieldService.Delete(metafieldID)
 }
 
 // ListOrders retrieves all orders from a customer
-func (s *CustomerServiceOp) ListOrders(customerID int, options interface{}) ([]Order, error) {
+func (s *CustomerServiceOp) ListOrders(customerID int64, options interface{}) ([]Order, error) {
 	path := fmt.Sprintf("%s/%d/orders.json", customersBasePath, customerID)
 	resource := new(OrdersResource)
 	err := s.client.Get(path, resource, options)

--- a/customer.go
+++ b/customer.go
@@ -36,7 +36,7 @@ type CustomerServiceOp struct {
 
 // Customer represents a Shopify customer
 type Customer struct {
-	ID                  int64                `json:"id,omitempty"`
+	ID                  int64              `json:"id,omitempty"`
 	Email               string             `json:"email,omitempty"`
 	FirstName           string             `json:"first_name,omitempty"`
 	LastName            string             `json:"last_name,omitempty"`
@@ -49,7 +49,7 @@ type Customer struct {
 	TotalSpent          *decimal.Decimal   `json:"total_spent,omitempty"`
 	Phone               string             `json:"phone,omitempty"`
 	Tags                string             `json:"tags,omitempty"`
-	LastOrderId         int64                `json:"last_order_id,omitempty"`
+	LastOrderId         int64              `json:"last_order_id,omitempty"`
 	LastOrderName       string             `json:"last_order_name,omitempty"`
 	AcceptsMarketing    bool               `json:"accepts_marketing,omitempty"`
 	DefaultAddress      *CustomerAddress   `json:"default_address,omitempty"`

--- a/customer_address.go
+++ b/customer_address.go
@@ -8,11 +8,11 @@ const customerAddressResourceName = "customer-addresses"
 // of the Shopify API.
 // See: https://help.shopify.com/en/api/reference/customers/customer_address
 type CustomerAddressService interface {
-	List(int, interface{}) ([]CustomerAddress, error)
-	Get(int, int, interface{}) (*CustomerAddress, error)
-	Create(int, CustomerAddress) (*CustomerAddress, error)
-	Update(int, CustomerAddress) (*CustomerAddress, error)
-	Delete(int, int) error
+	List(int64, interface{}) ([]CustomerAddress, error)
+	Get(int64, int64, interface{}) (*CustomerAddress, error)
+	Create(int64, CustomerAddress) (*CustomerAddress, error)
+	Update(int64, CustomerAddress) (*CustomerAddress, error)
+	Delete(int64, int64) error
 }
 
 // CustomerAddressServiceOp handles communication with the customer address related methods of
@@ -23,8 +23,8 @@ type CustomerAddressServiceOp struct {
 
 // CustomerAddress represents a Shopify customer address
 type CustomerAddress struct {
-	ID           int    `json:"id,omitempty"`
-	CustomerID   int    `json:"customer_id,omitempty"`
+	ID           int64    `json:"id,omitempty"`
+	CustomerID   int64    `json:"customer_id,omitempty"`
 	FirstName    string `json:"first_name,omitempty"`
 	LastName     string `json:"last_name,omitempty"`
 	Company      string `json:"company,omitempty"`
@@ -53,7 +53,7 @@ type CustomerAddressesResource struct {
 }
 
 // List addresses
-func (s *CustomerAddressServiceOp) List(customerID int, options interface{}) ([]CustomerAddress, error) {
+func (s *CustomerAddressServiceOp) List(customerID int64, options interface{}) ([]CustomerAddress, error) {
 	path := fmt.Sprintf("%s/%d/addresses.json", customersBasePath, customerID)
 	resource := new(CustomerAddressesResource)
 	err := s.client.Get(path, resource, options)
@@ -61,7 +61,7 @@ func (s *CustomerAddressServiceOp) List(customerID int, options interface{}) ([]
 }
 
 // Get address
-func (s *CustomerAddressServiceOp) Get(customerID, addressID int, options interface{}) (*CustomerAddress, error) {
+func (s *CustomerAddressServiceOp) Get(customerID, addressID int64, options interface{}) (*CustomerAddress, error) {
 	path := fmt.Sprintf("%s/%d/addresses/%d.json", customersBasePath, customerID, addressID)
 	resource := new(CustomerAddressResource)
 	err := s.client.Get(path, resource, options)
@@ -69,7 +69,7 @@ func (s *CustomerAddressServiceOp) Get(customerID, addressID int, options interf
 }
 
 // Create a new address for given customer
-func (s *CustomerAddressServiceOp) Create(customerID int, address CustomerAddress) (*CustomerAddress, error) {
+func (s *CustomerAddressServiceOp) Create(customerID int64, address CustomerAddress) (*CustomerAddress, error) {
 	path := fmt.Sprintf("%s/%d/addresses.json", customersBasePath, customerID)
 	wrappedData := CustomerAddressResource{Address: &address}
 	resource := new(CustomerAddressResource)
@@ -78,7 +78,7 @@ func (s *CustomerAddressServiceOp) Create(customerID int, address CustomerAddres
 }
 
 // Create a new address for given customer
-func (s *CustomerAddressServiceOp) Update(customerID int, address CustomerAddress) (*CustomerAddress, error) {
+func (s *CustomerAddressServiceOp) Update(customerID int64, address CustomerAddress) (*CustomerAddress, error) {
 	path := fmt.Sprintf("%s/%d/addresses/%d.json", customersBasePath, customerID, address.ID)
 	wrappedData := CustomerAddressResource{Address: &address}
 	resource := new(CustomerAddressResource)
@@ -87,6 +87,6 @@ func (s *CustomerAddressServiceOp) Update(customerID int, address CustomerAddres
 }
 
 // Delete an existing address
-func (s *CustomerAddressServiceOp) Delete(customerID, addressID int) error {
+func (s *CustomerAddressServiceOp) Delete(customerID, addressID int64) error {
 	return s.client.Delete(fmt.Sprintf("%s/%d/addresses/%d.json", customersBasePath, customerID, addressID))
 }

--- a/customer_address.go
+++ b/customer_address.go
@@ -23,8 +23,8 @@ type CustomerAddressServiceOp struct {
 
 // CustomerAddress represents a Shopify customer address
 type CustomerAddress struct {
-	ID           int64    `json:"id,omitempty"`
-	CustomerID   int64    `json:"customer_id,omitempty"`
+	ID           int64  `json:"id,omitempty"`
+	CustomerID   int64  `json:"customer_id,omitempty"`
 	FirstName    string `json:"first_name,omitempty"`
 	LastName     string `json:"last_name,omitempty"`
 	Company      string `json:"company,omitempty"`

--- a/customer_address_test.go
+++ b/customer_address_test.go
@@ -7,12 +7,12 @@ import (
 )
 
 func verifyAddress(t *testing.T, address CustomerAddress) {
-	expectedID := 1
+	expectedID := int64(1)
 	if address.ID != expectedID {
 		t.Errorf("CustomerAddress.ID returned %+v, expected %+v", address.ID, expectedID)
 	}
 
-	expectedCustomerID := 1
+	expectedCustomerID := int64(1)
 	if address.CustomerID != expectedCustomerID {
 		t.Errorf("CustomerAddress.CustomerID returned %+v, expected %+v", address.CustomerID, expectedCustomerID)
 	}

--- a/customer_test.go
+++ b/customer_test.go
@@ -247,7 +247,7 @@ func TestCustomerUpdate(t *testing.T) {
 		t.Errorf("Customer.Update returned error: %v", err)
 	}
 
-	expectedCustomerID := 1
+	expectedCustomerID := int64(1)
 	if returnedCustomer.ID != expectedCustomerID {
 		t.Errorf("Customer.ID returned %+v expected %+v", returnedCustomer.ID, expectedCustomerID)
 	}
@@ -270,7 +270,7 @@ func TestCustomerCreate(t *testing.T) {
 		t.Errorf("Customer.Create returned error: %v", err)
 	}
 
-	expectedCustomerID := 1
+	expectedCustomerID := int64(1)
 	if returnedCustomer.ID != expectedCustomerID {
 		t.Errorf("Customer.ID returned %+v expected %+v", returnedCustomer.ID, expectedCustomerID)
 	}

--- a/discount_code.go
+++ b/discount_code.go
@@ -26,8 +26,8 @@ type DiscountCodeServiceOp struct {
 
 // PriceRuleDiscountCode represents a Shopify Discount Code
 type PriceRuleDiscountCode struct {
-	ID          int64        `json:"id,omitempty"`
-	PriceRuleID int64        `json:"price_rule_id,omitempty"`
+	ID          int64      `json:"id,omitempty"`
+	PriceRuleID int64      `json:"price_rule_id,omitempty"`
 	Code        string     `json:"code,omitempty"`
 	UsageCount  int        `json:"usage_count,omitempty"`
 	CreatedAt   *time.Time `json:"created_at,omitempty"`

--- a/discount_code.go
+++ b/discount_code.go
@@ -11,11 +11,11 @@ const discountCodeBasePath = "/admin/price_rules/%d/discount_codes"
 // of the Shopify API.
 // See: https://help.shopify.com/en/api/reference/discounts/PriceRuleDiscountCode
 type DiscountCodeService interface {
-	Create(int, PriceRuleDiscountCode) (*PriceRuleDiscountCode, error)
-	Update(int, PriceRuleDiscountCode) (*PriceRuleDiscountCode, error)
-	List(int) ([]PriceRuleDiscountCode, error)
-	Get(int, int) (*PriceRuleDiscountCode, error)
-	Delete(int, int) error
+	Create(int64, PriceRuleDiscountCode) (*PriceRuleDiscountCode, error)
+	Update(int64, PriceRuleDiscountCode) (*PriceRuleDiscountCode, error)
+	List(int64) ([]PriceRuleDiscountCode, error)
+	Get(int64, int64) (*PriceRuleDiscountCode, error)
+	Delete(int64, int64) error
 }
 
 // DiscountCodeServiceOp handles communication with the discount code
@@ -26,8 +26,8 @@ type DiscountCodeServiceOp struct {
 
 // PriceRuleDiscountCode represents a Shopify Discount Code
 type PriceRuleDiscountCode struct {
-	ID          int        `json:"id,omitempty"`
-	PriceRuleID int        `json:"price_rule_id,omitempty"`
+	ID          int64        `json:"id,omitempty"`
+	PriceRuleID int64        `json:"price_rule_id,omitempty"`
 	Code        string     `json:"code,omitempty"`
 	UsageCount  int        `json:"usage_count,omitempty"`
 	CreatedAt   *time.Time `json:"created_at,omitempty"`
@@ -45,7 +45,7 @@ type DiscountCodeResource struct {
 }
 
 // Create a discount code
-func (s *DiscountCodeServiceOp) Create(priceRuleID int, dc PriceRuleDiscountCode) (*PriceRuleDiscountCode, error) {
+func (s *DiscountCodeServiceOp) Create(priceRuleID int64, dc PriceRuleDiscountCode) (*PriceRuleDiscountCode, error) {
 	path := fmt.Sprintf(discountCodeBasePath+".json", priceRuleID)
 	wrappedData := DiscountCodeResource{PriceRuleDiscountCode: &dc}
 	resource := new(DiscountCodeResource)
@@ -54,7 +54,7 @@ func (s *DiscountCodeServiceOp) Create(priceRuleID int, dc PriceRuleDiscountCode
 }
 
 // Update an existing discount code
-func (s *DiscountCodeServiceOp) Update(priceRuleID int, dc PriceRuleDiscountCode) (*PriceRuleDiscountCode, error) {
+func (s *DiscountCodeServiceOp) Update(priceRuleID int64, dc PriceRuleDiscountCode) (*PriceRuleDiscountCode, error) {
 	path := fmt.Sprintf(discountCodeBasePath+"/%d.json", priceRuleID, dc.ID)
 	wrappedData := DiscountCodeResource{PriceRuleDiscountCode: &dc}
 	resource := new(DiscountCodeResource)
@@ -63,7 +63,7 @@ func (s *DiscountCodeServiceOp) Update(priceRuleID int, dc PriceRuleDiscountCode
 }
 
 // List of discount codes
-func (s *DiscountCodeServiceOp) List(priceRuleID int) ([]PriceRuleDiscountCode, error) {
+func (s *DiscountCodeServiceOp) List(priceRuleID int64) ([]PriceRuleDiscountCode, error) {
 	path := fmt.Sprintf(discountCodeBasePath+".json", priceRuleID)
 	resource := new(DiscountCodesResource)
 	err := s.client.Get(path, resource, nil)
@@ -71,7 +71,7 @@ func (s *DiscountCodeServiceOp) List(priceRuleID int) ([]PriceRuleDiscountCode, 
 }
 
 // Get a single discount code
-func (s *DiscountCodeServiceOp) Get(priceRuleID int, discountCodeID int) (*PriceRuleDiscountCode, error) {
+func (s *DiscountCodeServiceOp) Get(priceRuleID int64, discountCodeID int64) (*PriceRuleDiscountCode, error) {
 	path := fmt.Sprintf(discountCodeBasePath+"/%d.json", priceRuleID, discountCodeID)
 	resource := new(DiscountCodeResource)
 	err := s.client.Get(path, resource, nil)
@@ -79,6 +79,6 @@ func (s *DiscountCodeServiceOp) Get(priceRuleID int, discountCodeID int) (*Price
 }
 
 // Delete a discount code
-func (s *DiscountCodeServiceOp) Delete(priceRuleID int, discountCodeID int) error {
+func (s *DiscountCodeServiceOp) Delete(priceRuleID int64, discountCodeID int64) error {
 	return s.client.Delete(fmt.Sprintf(discountCodeBasePath+"/%d.json", priceRuleID, discountCodeID))
 }

--- a/discount_code_test.go
+++ b/discount_code_test.go
@@ -79,7 +79,7 @@ func TestDiscountCodeCreate(t *testing.T) {
 		t.Errorf("DiscountCode.Create returned error: %v", err)
 	}
 
-	expectedInt := 1054381139
+	expectedInt := int64(1054381139)
 	if returnedDC.ID != expectedInt {
 		t.Errorf("DiscountCode.ID returned %+v, expected %+v", returnedDC.ID, expectedInt)
 	}
@@ -100,7 +100,7 @@ func TestDiscountCodeUpdate(t *testing.T) {
 	)
 
 	dc := PriceRuleDiscountCode{
-		ID:   1054381139,
+		ID:   int64(1054381139),
 		Code: "SUMMERSALE10OFF",
 	}
 
@@ -109,7 +109,7 @@ func TestDiscountCodeUpdate(t *testing.T) {
 		t.Errorf("DiscountCode.Update returned error: %v", err)
 	}
 
-	expectedInt := 1054381139
+	expectedInt := int64(1054381139)
 	if returnedDC.ID != expectedInt {
 		t.Errorf("DiscountCode.ID returned %+v, expected %+v", returnedDC.ID, expectedInt)
 	}

--- a/fulfillment.go
+++ b/fulfillment.go
@@ -43,9 +43,9 @@ type FulfillmentServiceOp struct {
 
 // Fulfillment represents a Shopify fulfillment.
 type Fulfillment struct {
-	ID              int64        `json:"id,omitempty"`
-	OrderID         int64        `json:"order_id,omitempty"`
-	LocationID      int64        `json:"location_id,omitempty"`
+	ID              int64      `json:"id,omitempty"`
+	OrderID         int64      `json:"order_id,omitempty"`
+	LocationID      int64      `json:"location_id,omitempty"`
 	Status          string     `json:"status,omitempty"`
 	CreatedAt       *time.Time `json:"created_at,omitempty"`
 	Service         string     `json:"service,omitempty"`

--- a/fulfillment.go
+++ b/fulfillment.go
@@ -11,26 +11,26 @@ import (
 type FulfillmentService interface {
 	List(interface{}) ([]Fulfillment, error)
 	Count(interface{}) (int, error)
-	Get(int, interface{}) (*Fulfillment, error)
+	Get(int64, interface{}) (*Fulfillment, error)
 	Create(Fulfillment) (*Fulfillment, error)
 	Update(Fulfillment) (*Fulfillment, error)
-	Complete(int) (*Fulfillment, error)
-	Transition(int) (*Fulfillment, error)
-	Cancel(int) (*Fulfillment, error)
+	Complete(int64) (*Fulfillment, error)
+	Transition(int64) (*Fulfillment, error)
+	Cancel(int64) (*Fulfillment, error)
 }
 
 // FulfillmentsService is an interface for other Shopify resources
 // to interface with the fulfillment endpoints of the Shopify API.
 // https://help.shopify.com/api/reference/fulfillment
 type FulfillmentsService interface {
-	ListFulfillments(int, interface{}) ([]Fulfillment, error)
-	CountFulfillments(int, interface{}) (int, error)
-	GetFulfillment(int, int, interface{}) (*Fulfillment, error)
-	CreateFulfillment(int, Fulfillment) (*Fulfillment, error)
-	UpdateFulfillment(int, Fulfillment) (*Fulfillment, error)
-	CompleteFulfillment(int, int) (*Fulfillment, error)
-	TransitionFulfillment(int, int) (*Fulfillment, error)
-	CancelFulfillment(int, int) (*Fulfillment, error)
+	ListFulfillments(int64, interface{}) ([]Fulfillment, error)
+	CountFulfillments(int64, interface{}) (int, error)
+	GetFulfillment(int64, int64, interface{}) (*Fulfillment, error)
+	CreateFulfillment(int64, Fulfillment) (*Fulfillment, error)
+	UpdateFulfillment(int64, Fulfillment) (*Fulfillment, error)
+	CompleteFulfillment(int64, int64) (*Fulfillment, error)
+	TransitionFulfillment(int64, int64) (*Fulfillment, error)
+	CancelFulfillment(int64, int64) (*Fulfillment, error)
 }
 
 // FulfillmentServiceOp handles communication with the fulfillment
@@ -38,14 +38,14 @@ type FulfillmentsService interface {
 type FulfillmentServiceOp struct {
 	client     *Client
 	resource   string
-	resourceID int
+	resourceID int64
 }
 
 // Fulfillment represents a Shopify fulfillment.
 type Fulfillment struct {
-	ID              int        `json:"id,omitempty"`
-	OrderID         int        `json:"order_id,omitempty"`
-	LocationID      int        `json:"location_id,omitempty"`
+	ID              int64        `json:"id,omitempty"`
+	OrderID         int64        `json:"order_id,omitempty"`
+	LocationID      int64        `json:"location_id,omitempty"`
 	Status          string     `json:"status,omitempty"`
 	CreatedAt       *time.Time `json:"created_at,omitempty"`
 	Service         string     `json:"service,omitempty"`
@@ -94,7 +94,7 @@ func (s *FulfillmentServiceOp) Count(options interface{}) (int, error) {
 }
 
 // Get individual fulfillment
-func (s *FulfillmentServiceOp) Get(fulfillmentID int, options interface{}) (*Fulfillment, error) {
+func (s *FulfillmentServiceOp) Get(fulfillmentID int64, options interface{}) (*Fulfillment, error) {
 	prefix := FulfillmentPathPrefix(s.resource, s.resourceID)
 	path := fmt.Sprintf("%s/%d.json", prefix, fulfillmentID)
 	resource := new(FulfillmentResource)
@@ -123,7 +123,7 @@ func (s *FulfillmentServiceOp) Update(fulfillment Fulfillment) (*Fulfillment, er
 }
 
 // Complete an existing fulfillment
-func (s *FulfillmentServiceOp) Complete(fulfillmentID int) (*Fulfillment, error) {
+func (s *FulfillmentServiceOp) Complete(fulfillmentID int64) (*Fulfillment, error) {
 	prefix := FulfillmentPathPrefix(s.resource, s.resourceID)
 	path := fmt.Sprintf("%s/%d/complete.json", prefix, fulfillmentID)
 	resource := new(FulfillmentResource)
@@ -132,7 +132,7 @@ func (s *FulfillmentServiceOp) Complete(fulfillmentID int) (*Fulfillment, error)
 }
 
 // Transition an existing fulfillment
-func (s *FulfillmentServiceOp) Transition(fulfillmentID int) (*Fulfillment, error) {
+func (s *FulfillmentServiceOp) Transition(fulfillmentID int64) (*Fulfillment, error) {
 	prefix := FulfillmentPathPrefix(s.resource, s.resourceID)
 	path := fmt.Sprintf("%s/%d/open.json", prefix, fulfillmentID)
 	resource := new(FulfillmentResource)
@@ -141,7 +141,7 @@ func (s *FulfillmentServiceOp) Transition(fulfillmentID int) (*Fulfillment, erro
 }
 
 // Cancel an existing fulfillment
-func (s *FulfillmentServiceOp) Cancel(fulfillmentID int) (*Fulfillment, error) {
+func (s *FulfillmentServiceOp) Cancel(fulfillmentID int64) (*Fulfillment, error) {
 	prefix := FulfillmentPathPrefix(s.resource, s.resourceID)
 	path := fmt.Sprintf("%s/%d/cancel.json", prefix, fulfillmentID)
 	resource := new(FulfillmentResource)

--- a/fulfillment_test.go
+++ b/fulfillment_test.go
@@ -10,7 +10,7 @@ import (
 
 func FulfillmentTests(t *testing.T, fulfillment Fulfillment) {
 	// Check that ID is assigned to the returned fulfillment
-	expectedInt := 1022782888
+	expectedInt := int64(1022782888)
 	if fulfillment.ID != expectedInt {
 		t.Errorf("Fulfillment.ID returned %+v, expected %+v", fulfillment.ID, expectedInt)
 	}

--- a/goshopify.go
+++ b/goshopify.go
@@ -357,7 +357,8 @@ type ListOptions struct {
 	UpdatedAtMax time.Time `url:"updated_at_max,omitempty"`
 	Order        string    `url:"order,omitempty"`
 	Fields       string    `url:"fields,omitempty"`
-	IDs          []int     `url:"ids,omitempty,comma"`
+	Vendor       string    `url:"vendor,omitempty"`
+	IDs          []int64   `url:"ids,omitempty,comma"`
 }
 
 // General count options that can be used for most collection counts.

--- a/goshopify.go
+++ b/goshopify.go
@@ -350,7 +350,7 @@ func CheckResponseError(r *http.Response) error {
 type ListOptions struct {
 	Page         int       `url:"page,omitempty"`
 	Limit        int       `url:"limit,omitempty"`
-	SinceID      int       `url:"since_id,omitempty"`
+	SinceID      int64     `url:"since_id,omitempty"`
 	CreatedAtMin time.Time `url:"created_at_min,omitempty"`
 	CreatedAtMax time.Time `url:"created_at_max,omitempty"`
 	UpdatedAtMin time.Time `url:"updated_at_min,omitempty"`

--- a/image.go
+++ b/image.go
@@ -25,8 +25,8 @@ type ImageServiceOp struct {
 
 // Image represents a Shopify product's image.
 type Image struct {
-	ID         int64        `json:"id,omitempty"`
-	ProductID  int64        `json:"product_id,omitempty"`
+	ID         int64      `json:"id,omitempty"`
+	ProductID  int64      `json:"product_id,omitempty"`
 	Position   int        `json:"position,omitempty"`
 	CreatedAt  *time.Time `json:"created_at,omitempty"`
 	UpdatedAt  *time.Time `json:"updated_at,omitempty"`
@@ -35,7 +35,7 @@ type Image struct {
 	Src        string     `json:"src,omitempty"`
 	Attachment string     `json:"attachment,omitempty"`
 	Filename   string     `json:"filename,omitempty"`
-	VariantIds []int64      `json:"variant_ids,omitempty"`
+	VariantIds []int64    `json:"variant_ids,omitempty"`
 }
 
 // ImageResource represents the result form the products/X/images/Y.json endpoint

--- a/image.go
+++ b/image.go
@@ -9,12 +9,12 @@ import (
 // of the Shopify API.
 // See https://help.shopify.com/api/reference/product_image
 type ImageService interface {
-	List(int, interface{}) ([]Image, error)
-	Count(int, interface{}) (int, error)
-	Get(int, int, interface{}) (*Image, error)
-	Create(int, Image) (*Image, error)
-	Update(int, Image) (*Image, error)
-	Delete(int, int) error
+	List(int64, interface{}) ([]Image, error)
+	Count(int64, interface{}) (int, error)
+	Get(int64, int64, interface{}) (*Image, error)
+	Create(int64, Image) (*Image, error)
+	Update(int64, Image) (*Image, error)
+	Delete(int64, int64) error
 }
 
 // ImageServiceOp handles communication with the image related methods of
@@ -25,8 +25,8 @@ type ImageServiceOp struct {
 
 // Image represents a Shopify product's image.
 type Image struct {
-	ID         int        `json:"id,omitempty"`
-	ProductID  int        `json:"product_id,omitempty"`
+	ID         int64        `json:"id,omitempty"`
+	ProductID  int64        `json:"product_id,omitempty"`
 	Position   int        `json:"position,omitempty"`
 	CreatedAt  *time.Time `json:"created_at,omitempty"`
 	UpdatedAt  *time.Time `json:"updated_at,omitempty"`
@@ -35,7 +35,7 @@ type Image struct {
 	Src        string     `json:"src,omitempty"`
 	Attachment string     `json:"attachment,omitempty"`
 	Filename   string     `json:"filename,omitempty"`
-	VariantIds []int      `json:"variant_ids,omitempty"`
+	VariantIds []int64      `json:"variant_ids,omitempty"`
 }
 
 // ImageResource represents the result form the products/X/images/Y.json endpoint
@@ -49,7 +49,7 @@ type ImagesResource struct {
 }
 
 // List images
-func (s *ImageServiceOp) List(productID int, options interface{}) ([]Image, error) {
+func (s *ImageServiceOp) List(productID int64, options interface{}) ([]Image, error) {
 	path := fmt.Sprintf("%s/%d/images.json", productsBasePath, productID)
 	resource := new(ImagesResource)
 	err := s.client.Get(path, resource, options)
@@ -57,13 +57,13 @@ func (s *ImageServiceOp) List(productID int, options interface{}) ([]Image, erro
 }
 
 // Count images
-func (s *ImageServiceOp) Count(productID int, options interface{}) (int, error) {
+func (s *ImageServiceOp) Count(productID int64, options interface{}) (int, error) {
 	path := fmt.Sprintf("%s/%d/images/count.json", productsBasePath, productID)
 	return s.client.Count(path, options)
 }
 
 // Get individual image
-func (s *ImageServiceOp) Get(productID int, imageID int, options interface{}) (*Image, error) {
+func (s *ImageServiceOp) Get(productID int64, imageID int64, options interface{}) (*Image, error) {
 	path := fmt.Sprintf("%s/%d/images/%d.json", productsBasePath, productID, imageID)
 	resource := new(ImageResource)
 	err := s.client.Get(path, resource, options)
@@ -83,7 +83,7 @@ func (s *ImageServiceOp) Get(productID int, imageID int, options interface{}) (*
 // Shopify will take the attachment.
 //
 // Shopify will accept Image.Attachment without Image.Filename.
-func (s *ImageServiceOp) Create(productID int, image Image) (*Image, error) {
+func (s *ImageServiceOp) Create(productID int64, image Image) (*Image, error) {
 	path := fmt.Sprintf("%s/%d/images.json", productsBasePath, productID)
 	wrappedData := ImageResource{Image: &image}
 	resource := new(ImageResource)
@@ -92,7 +92,7 @@ func (s *ImageServiceOp) Create(productID int, image Image) (*Image, error) {
 }
 
 // Update an existing image
-func (s *ImageServiceOp) Update(productID int, image Image) (*Image, error) {
+func (s *ImageServiceOp) Update(productID int64, image Image) (*Image, error) {
 	path := fmt.Sprintf("%s/%d/images/%d.json", productsBasePath, productID, image.ID)
 	wrappedData := ImageResource{Image: &image}
 	resource := new(ImageResource)
@@ -101,6 +101,6 @@ func (s *ImageServiceOp) Update(productID int, image Image) (*Image, error) {
 }
 
 // Delete an existing image
-func (s *ImageServiceOp) Delete(productID int, imageID int) error {
+func (s *ImageServiceOp) Delete(productID int64, imageID int64) error {
 	return s.client.Delete(fmt.Sprintf("%s/%d/images/%d.json", productsBasePath, productID, imageID))
 }

--- a/image_test.go
+++ b/image_test.go
@@ -9,13 +9,13 @@ import (
 
 func imageTests(t *testing.T, image Image) {
 	// Check that ID is set
-	expectedImageID := 1
+	expectedImageID := int64(1)
 	if image.ID != expectedImageID {
 		t.Errorf("Image.ID returned %+v, expected %+v", image.ID, expectedImageID)
 	}
 
 	// Check that product_id is set
-	expectedProductID := 1
+	expectedProductID := int64(1)
 	if image.ProductID != expectedProductID {
 		t.Errorf("Image.ProductID returned %+v, expected %+v", image.ProductID, expectedProductID)
 	}
@@ -45,7 +45,7 @@ func imageTests(t *testing.T, image Image) {
 	}
 
 	// Check that variant ids are set
-	expectedVariantIds := make([]int, 2)
+	expectedVariantIds := make([]int64, 2)
 	expectedVariantIds[0] = 808950810
 	expectedVariantIds[1] = 808950811
 
@@ -147,7 +147,7 @@ func TestImageCreate(t *testing.T) {
 	httpmock.RegisterResponder("POST", "https://fooshop.myshopify.com/admin/products/1/images.json",
 		httpmock.NewBytesResponder(200, loadFixture("image.json")))
 
-	variantIds := make([]int, 2)
+	variantIds := make([]int64, 2)
 	variantIds[0] = 808950810
 	variantIds[1] = 808950811
 
@@ -171,7 +171,7 @@ func TestImageUpdate(t *testing.T) {
 		httpmock.NewBytesResponder(200, loadFixture("image.json")))
 
 	// Take an existing image
-	variantIds := make([]int, 2)
+	variantIds := make([]int64, 2)
 	variantIds[0] = 808950810
 	variantIds[1] = 457924702
 	existingImage := Image{

--- a/inventory_item.go
+++ b/inventory_item.go
@@ -14,7 +14,7 @@ const inventoryItemsBasePath = "admin/inventory_items"
 // See https://help.shopify.com/en/api/reference/inventory/inventoryitem
 type InventoryItemService interface {
 	List(interface{}) ([]InventoryItem, error)
-	Get(int, interface{}) (*InventoryItem, error)
+	Get(int64, interface{}) (*InventoryItem, error)
 	Update(InventoryItem) (*InventoryItem, error)
 }
 
@@ -25,7 +25,7 @@ type InventoryItemServiceOp struct {
 
 // InventoryItem represents a Shopify inventory item
 type InventoryItem struct {
-	ID                int              `json:"id,omitempty"`
+	ID                int64              `json:"id,omitempty"`
 	SKU               string           `json:"sku,omitempty"`
 	CreatedAt         *time.Time       `json:"created_at,omitempty"`
 	UpdatedAt         *time.Time       `json:"updated_at,omitempty"`
@@ -53,7 +53,7 @@ func (s *InventoryItemServiceOp) List(options interface{}) ([]InventoryItem, err
 }
 
 // Get a inventory item
-func (s *InventoryItemServiceOp) Get(id int, options interface{}) (*InventoryItem, error) {
+func (s *InventoryItemServiceOp) Get(id int64, options interface{}) (*InventoryItem, error) {
 	path := fmt.Sprintf("%s/%d.json", inventoryItemsBasePath, id)
 	resource := new(InventoryItemResource)
 	err := s.client.Get(path, resource, options)

--- a/inventory_item.go
+++ b/inventory_item.go
@@ -25,7 +25,7 @@ type InventoryItemServiceOp struct {
 
 // InventoryItem represents a Shopify inventory item
 type InventoryItem struct {
-	ID                int64              `json:"id,omitempty"`
+	ID                int64            `json:"id,omitempty"`
 	SKU               string           `json:"sku,omitempty"`
 	CreatedAt         *time.Time       `json:"created_at,omitempty"`
 	UpdatedAt         *time.Time       `json:"updated_at,omitempty"`

--- a/inventory_item_test.go
+++ b/inventory_item_test.go
@@ -12,7 +12,7 @@ func inventoryItemTests(t *testing.T, item *InventoryItem) {
 		return
 	}
 
-	expectedInt := 808950810
+	expectedInt := int64(808950810)
 	if item.ID != expectedInt {
 		t.Errorf("InventoryItem.ID returned %+v, expected %+v", item.ID, expectedInt)
 	}

--- a/inventory_item_test.go
+++ b/inventory_item_test.go
@@ -71,7 +71,7 @@ func TestInventoryItemsListWithIDs(t *testing.T) {
 	)
 
 	options := ListOptions{
-		IDs: []int{1, 2},
+		IDs: []int64{1, 2},
 	}
 
 	items, err := client.InventoryItem.List(options)

--- a/location.go
+++ b/location.go
@@ -14,7 +14,7 @@ type LocationService interface {
 	// Retrieves a list of locations
 	List(options interface{}) ([]Location, error)
 	// Retrieves a single location by its ID
-	Get(ID int, options interface{}) (*Location, error)
+	Get(ID int64, options interface{}) (*Location, error)
 	// Retrieves a count of locations
 	Count(options interface{}) (int, error)
 }
@@ -46,7 +46,7 @@ type Location struct {
 	CreatedAt time.Time `json:"created_at"`
 
 	// The ID for the location.
-	ID int `json:"id"`
+	ID int64 `json:"id"`
 
 	// Whether this is a fulfillment service location.
 	// If true, then the location is a fulfillment service location.
@@ -87,7 +87,7 @@ func (s *LocationServiceOp) List(options interface{}) ([]Location, error) {
 	return resource.Locations, err
 }
 
-func (s *LocationServiceOp) Get(ID int, options interface{}) (*Location, error) {
+func (s *LocationServiceOp) Get(ID int64, options interface{}) (*Location, error) {
 	path := fmt.Sprintf("%s/%d.json", locationsBasePath, ID)
 	resource := new(LocationResource)
 	err := s.client.Get(path, resource, options)

--- a/metafield.go
+++ b/metafield.go
@@ -39,13 +39,13 @@ type MetafieldServiceOp struct {
 
 // Metafield represents a Shopify metafield.
 type Metafield struct {
-	ID            int64         `json:"id,omitempty"`
+	ID            int64       `json:"id,omitempty"`
 	Key           string      `json:"key,omitempty"`
 	Value         interface{} `json:"value,omitempty"`
 	ValueType     string      `json:"value_type,omitempty"`
 	Namespace     string      `json:"namespace,omitempty"`
 	Description   string      `json:"description,omitempty"`
-	OwnerId       int64         `json:"owner_id,omitempty"`
+	OwnerId       int64       `json:"owner_id,omitempty"`
 	CreatedAt     *time.Time  `json:"created_at,omitempty"`
 	UpdatedAt     *time.Time  `json:"updated_at,omitempty"`
 	OwnerResource string      `json:"owner_resource,omitempty"`

--- a/metafield.go
+++ b/metafield.go
@@ -11,22 +11,22 @@ import (
 type MetafieldService interface {
 	List(interface{}) ([]Metafield, error)
 	Count(interface{}) (int, error)
-	Get(int, interface{}) (*Metafield, error)
+	Get(int64, interface{}) (*Metafield, error)
 	Create(Metafield) (*Metafield, error)
 	Update(Metafield) (*Metafield, error)
-	Delete(int) error
+	Delete(int64) error
 }
 
 // MetafieldsService is an interface for other Shopify resources
 // to interface with the metafield endpoints of the Shopify API.
 // https://help.shopify.com/api/reference/metafield
 type MetafieldsService interface {
-	ListMetafields(int, interface{}) ([]Metafield, error)
-	CountMetafields(int, interface{}) (int, error)
-	GetMetafield(int, int, interface{}) (*Metafield, error)
-	CreateMetafield(int, Metafield) (*Metafield, error)
-	UpdateMetafield(int, Metafield) (*Metafield, error)
-	DeleteMetafield(int, int) error
+	ListMetafields(int64, interface{}) ([]Metafield, error)
+	CountMetafields(int64, interface{}) (int, error)
+	GetMetafield(int64, int64, interface{}) (*Metafield, error)
+	CreateMetafield(int64, Metafield) (*Metafield, error)
+	UpdateMetafield(int64, Metafield) (*Metafield, error)
+	DeleteMetafield(int64, int64) error
 }
 
 // MetafieldServiceOp handles communication with the metafield
@@ -34,18 +34,18 @@ type MetafieldsService interface {
 type MetafieldServiceOp struct {
 	client     *Client
 	resource   string
-	resourceID int
+	resourceID int64
 }
 
 // Metafield represents a Shopify metafield.
 type Metafield struct {
-	ID            int         `json:"id,omitempty"`
+	ID            int64         `json:"id,omitempty"`
 	Key           string      `json:"key,omitempty"`
 	Value         interface{} `json:"value,omitempty"`
 	ValueType     string      `json:"value_type,omitempty"`
 	Namespace     string      `json:"namespace,omitempty"`
 	Description   string      `json:"description,omitempty"`
-	OwnerId       int         `json:"owner_id,omitempty"`
+	OwnerId       int64         `json:"owner_id,omitempty"`
 	CreatedAt     *time.Time  `json:"created_at,omitempty"`
 	UpdatedAt     *time.Time  `json:"updated_at,omitempty"`
 	OwnerResource string      `json:"owner_resource,omitempty"`
@@ -78,7 +78,7 @@ func (s *MetafieldServiceOp) Count(options interface{}) (int, error) {
 }
 
 // Get individual metafield
-func (s *MetafieldServiceOp) Get(metafieldID int, options interface{}) (*Metafield, error) {
+func (s *MetafieldServiceOp) Get(metafieldID int64, options interface{}) (*Metafield, error) {
 	prefix := MetafieldPathPrefix(s.resource, s.resourceID)
 	path := fmt.Sprintf("%s/%d.json", prefix, metafieldID)
 	resource := new(MetafieldResource)
@@ -107,7 +107,7 @@ func (s *MetafieldServiceOp) Update(metafield Metafield) (*Metafield, error) {
 }
 
 // Delete an existing metafield
-func (s *MetafieldServiceOp) Delete(metafieldID int) error {
+func (s *MetafieldServiceOp) Delete(metafieldID int64) error {
 	prefix := MetafieldPathPrefix(s.resource, s.resourceID)
 	return s.client.Delete(fmt.Sprintf("%s/%d.json", prefix, metafieldID))
 }

--- a/metafield_test.go
+++ b/metafield_test.go
@@ -10,7 +10,7 @@ import (
 
 func MetafieldTests(t *testing.T, metafield Metafield) {
 	// Check that ID is assigned to the returned metafield
-	expectedInt := 721389482
+	expectedInt := int64(721389482)
 	if metafield.ID != expectedInt {
 		t.Errorf("Metafield.ID returned %+v, expected %+v", metafield.ID, expectedInt)
 	}

--- a/order.go
+++ b/order.go
@@ -37,7 +37,7 @@ type OrderServiceOp struct {
 type OrderCountOptions struct {
 	Page              int       `url:"page,omitempty"`
 	Limit             int       `url:"limit,omitempty"`
-	SinceID           int64       `url:"since_id,omitempty"`
+	SinceID           int64     `url:"since_id,omitempty"`
 	CreatedAtMin      time.Time `url:"created_at_min,omitempty"`
 	CreatedAtMax      time.Time `url:"created_at_max,omitempty"`
 	UpdatedAtMin      time.Time `url:"updated_at_min,omitempty"`
@@ -54,7 +54,7 @@ type OrderCountOptions struct {
 type OrderListOptions struct {
 	Page              int       `url:"page,omitempty"`
 	Limit             int       `url:"limit,omitempty"`
-	SinceID           int64       `url:"since_id,omitempty"`
+	SinceID           int64     `url:"since_id,omitempty"`
 	Status            string    `url:"status,omitempty"`
 	FinancialStatus   string    `url:"financial_status,omitempty"`
 	FulfillmentStatus string    `url:"fulfillment_status,omitempty"`
@@ -70,7 +70,7 @@ type OrderListOptions struct {
 
 // Order represents a Shopify order
 type Order struct {
-	ID                    int64              `json:"id,omitempty"`
+	ID                    int64            `json:"id,omitempty"`
 	Name                  string           `json:"name,omitempty"`
 	Email                 string           `json:"email,omitempty"`
 	CreatedAt             *time.Time       `json:"created_at,omitempty"`
@@ -114,11 +114,11 @@ type Order struct {
 	SourceName            string           `json:"source_name,omitempty"`
 	ClientDetails         *ClientDetails   `json:"client_details,omitempty"`
 	Tags                  string           `json:"tags,omitempty"`
-	LocationId            int64              `json:"location_id,omitempty"`
+	LocationId            int64            `json:"location_id,omitempty"`
 	PaymentGatewayNames   []string         `json:"payment_gateway_names,omitempty"`
 	ProcessingMethod      string           `json:"processing_method,omitempty"`
 	Refunds               []Refund         `json:"refunds,omitempty"`
-	UserId                int64              `json:"user_id,omitempty"`
+	UserId                int64            `json:"user_id,omitempty"`
 	OrderStatusUrl        string           `json:"order_status_url,omitempty"`
 	Gateway               string           `json:"gateway,omitempty"`
 	Confirmed             bool             `json:"confirmed,omitempty"`
@@ -127,16 +127,16 @@ type Order struct {
 	Reference             string           `json:"reference,omitempty"`
 	SourceIdentifier      string           `json:"source_identifier,omitempty"`
 	SourceURL             string           `json:"source_url,omitempty"`
-	DeviceID              int64              `json:"device_id,omitempty"`
+	DeviceID              int64            `json:"device_id,omitempty"`
 	Phone                 string           `json:"phone,omitempty"`
 	LandingSiteRef        string           `json:"landing_site_ref,omitempty"`
-	CheckoutID            int64              `json:"checkout_id,omitempty"`
+	CheckoutID            int64            `json:"checkout_id,omitempty"`
 	ContactEmail          string           `json:"contact_email,omitempty"`
 	Metafields            []Metafield      `json:"metafields,omitempty"`
 }
 
 type Address struct {
-	ID           int64     `json:"id,omitempty"`
+	ID           int64   `json:"id,omitempty"`
 	Address1     string  `json:"address1,omitempty"`
 	Address2     string  `json:"address2,omitempty"`
 	City         string  `json:"city,omitempty"`
@@ -161,9 +161,9 @@ type DiscountCode struct {
 }
 
 type LineItem struct {
-	ID                         int64              `json:"id,omitempty"`
-	ProductID                  int64              `json:"product_id,omitempty"`
-	VariantID                  int64              `json:"variant_id,omitempty"`
+	ID                         int64            `json:"id,omitempty"`
+	ProductID                  int64            `json:"product_id,omitempty"`
+	VariantID                  int64            `json:"variant_id,omitempty"`
 	Quantity                   int              `json:"quantity,omitempty"`
 	Price                      *decimal.Decimal `json:"price,omitempty"`
 	TotalDiscount              *decimal.Decimal `json:"total_discount,omitempty"`
@@ -216,7 +216,7 @@ type PaymentDetails struct {
 }
 
 type ShippingLines struct {
-	ID                            int64              `json:"id,omitempty"`
+	ID                            int64            `json:"id,omitempty"`
 	Title                         string           `json:"title,omitempty"`
 	Price                         *decimal.Decimal `json:"price,omitempty"`
 	Code                          string           `json:"code,omitempty"`
@@ -235,8 +235,8 @@ type TaxLine struct {
 }
 
 type Transaction struct {
-	ID             int64              `json:"id,omitempty"`
-	OrderID        int64              `json:"order_id,omitempty"`
+	ID             int64            `json:"id,omitempty"`
+	OrderID        int64            `json:"order_id,omitempty"`
 	Amount         *decimal.Decimal `json:"amount,omitempty"`
 	Kind           string           `json:"kind,omitempty"`
 	Gateway        string           `json:"gateway,omitempty"`
@@ -246,10 +246,10 @@ type Transaction struct {
 	Test           bool             `json:"test,omitempty"`
 	Authorization  string           `json:"authorization,omitempty"`
 	Currency       string           `json:"currency,omitempty"`
-	LocationID     *int64             `json:"location_id,omitempty"`
-	UserID         *int64             `json:"user_id,omitempty"`
-	ParentID       *int64             `json:"parent_id,omitempty"`
-	DeviceID       *int64             `json:"device_id,omitempty"`
+	LocationID     *int64           `json:"location_id,omitempty"`
+	UserID         *int64           `json:"user_id,omitempty"`
+	ParentID       *int64           `json:"parent_id,omitempty"`
+	DeviceID       *int64           `json:"device_id,omitempty"`
 	ErrorCode      string           `json:"error_code,omitempty"`
 	SourceName     string           `json:"source_name,omitempty"`
 	PaymentDetails *PaymentDetails  `json:"payment_details,omitempty"`
@@ -265,20 +265,20 @@ type ClientDetails struct {
 }
 
 type Refund struct {
-	Id              int64              `json:"id,omitempty"`
-	OrderId         int64              `json:"order_id,omitempty"`
+	Id              int64            `json:"id,omitempty"`
+	OrderId         int64            `json:"order_id,omitempty"`
 	CreatedAt       *time.Time       `json:"created_at,omitempty"`
 	Note            string           `json:"note,omitempty"`
 	Restock         bool             `json:"restock,omitempty"`
-	UserId          int64              `json:"user_id,omitempty"`
+	UserId          int64            `json:"user_id,omitempty"`
 	RefundLineItems []RefundLineItem `json:"refund_line_items,omitempty"`
 	Transactions    []Transaction    `json:"transactions,omitempty"`
 }
 
 type RefundLineItem struct {
-	Id         int64              `json:"id,omitempty"`
+	Id         int64            `json:"id,omitempty"`
 	Quantity   int              `json:"quantity,omitempty"`
-	LineItemId int64              `json:"line_item_id,omitempty"`
+	LineItemId int64            `json:"line_item_id,omitempty"`
 	LineItem   *LineItem        `json:"line_item,omitempty"`
 	Subtotal   *decimal.Decimal `json:"subtotal,omitempty"`
 	TotalTax   *decimal.Decimal `json:"total_tax,omitempty"`

--- a/order.go
+++ b/order.go
@@ -16,7 +16,7 @@ const ordersResourceName = "orders"
 type OrderService interface {
 	List(interface{}) ([]Order, error)
 	Count(interface{}) (int, error)
-	Get(int, interface{}) (*Order, error)
+	Get(int64, interface{}) (*Order, error)
 	Create(Order) (*Order, error)
 	Update(Order) (*Order, error)
 
@@ -37,7 +37,7 @@ type OrderServiceOp struct {
 type OrderCountOptions struct {
 	Page              int       `url:"page,omitempty"`
 	Limit             int       `url:"limit,omitempty"`
-	SinceID           int       `url:"since_id,omitempty"`
+	SinceID           int64       `url:"since_id,omitempty"`
 	CreatedAtMin      time.Time `url:"created_at_min,omitempty"`
 	CreatedAtMax      time.Time `url:"created_at_max,omitempty"`
 	UpdatedAtMin      time.Time `url:"updated_at_min,omitempty"`
@@ -54,7 +54,7 @@ type OrderCountOptions struct {
 type OrderListOptions struct {
 	Page              int       `url:"page,omitempty"`
 	Limit             int       `url:"limit,omitempty"`
-	SinceID           int       `url:"since_id,omitempty"`
+	SinceID           int64       `url:"since_id,omitempty"`
 	Status            string    `url:"status,omitempty"`
 	FinancialStatus   string    `url:"financial_status,omitempty"`
 	FulfillmentStatus string    `url:"fulfillment_status,omitempty"`
@@ -70,7 +70,7 @@ type OrderListOptions struct {
 
 // Order represents a Shopify order
 type Order struct {
-	ID                    int              `json:"id,omitempty"`
+	ID                    int64              `json:"id,omitempty"`
 	Name                  string           `json:"name,omitempty"`
 	Email                 string           `json:"email,omitempty"`
 	CreatedAt             *time.Time       `json:"created_at,omitempty"`
@@ -114,11 +114,11 @@ type Order struct {
 	SourceName            string           `json:"source_name,omitempty"`
 	ClientDetails         *ClientDetails   `json:"client_details,omitempty"`
 	Tags                  string           `json:"tags,omitempty"`
-	LocationId            int              `json:"location_id,omitempty"`
+	LocationId            int64              `json:"location_id,omitempty"`
 	PaymentGatewayNames   []string         `json:"payment_gateway_names,omitempty"`
 	ProcessingMethod      string           `json:"processing_method,omitempty"`
 	Refunds               []Refund         `json:"refunds,omitempty"`
-	UserId                int              `json:"user_id,omitempty"`
+	UserId                int64              `json:"user_id,omitempty"`
 	OrderStatusUrl        string           `json:"order_status_url,omitempty"`
 	Gateway               string           `json:"gateway,omitempty"`
 	Confirmed             bool             `json:"confirmed,omitempty"`
@@ -127,16 +127,16 @@ type Order struct {
 	Reference             string           `json:"reference,omitempty"`
 	SourceIdentifier      string           `json:"source_identifier,omitempty"`
 	SourceURL             string           `json:"source_url,omitempty"`
-	DeviceID              int              `json:"device_id,omitempty"`
+	DeviceID              int64              `json:"device_id,omitempty"`
 	Phone                 string           `json:"phone,omitempty"`
 	LandingSiteRef        string           `json:"landing_site_ref,omitempty"`
-	CheckoutID            int              `json:"checkout_id,omitempty"`
+	CheckoutID            int64              `json:"checkout_id,omitempty"`
 	ContactEmail          string           `json:"contact_email,omitempty"`
 	Metafields            []Metafield      `json:"metafields,omitempty"`
 }
 
 type Address struct {
-	ID           int     `json:"id,omitempty"`
+	ID           int64     `json:"id,omitempty"`
 	Address1     string  `json:"address1,omitempty"`
 	Address2     string  `json:"address2,omitempty"`
 	City         string  `json:"city,omitempty"`
@@ -161,9 +161,9 @@ type DiscountCode struct {
 }
 
 type LineItem struct {
-	ID                         int              `json:"id,omitempty"`
-	ProductID                  int              `json:"product_id,omitempty"`
-	VariantID                  int              `json:"variant_id,omitempty"`
+	ID                         int64              `json:"id,omitempty"`
+	ProductID                  int64              `json:"product_id,omitempty"`
+	VariantID                  int64              `json:"variant_id,omitempty"`
 	Quantity                   int              `json:"quantity,omitempty"`
 	Price                      *decimal.Decimal `json:"price,omitempty"`
 	TotalDiscount              *decimal.Decimal `json:"total_discount,omitempty"`
@@ -216,7 +216,7 @@ type PaymentDetails struct {
 }
 
 type ShippingLines struct {
-	ID                            int              `json:"id,omitempty"`
+	ID                            int64              `json:"id,omitempty"`
 	Title                         string           `json:"title,omitempty"`
 	Price                         *decimal.Decimal `json:"price,omitempty"`
 	Code                          string           `json:"code,omitempty"`
@@ -235,8 +235,8 @@ type TaxLine struct {
 }
 
 type Transaction struct {
-	ID             int              `json:"id,omitempty"`
-	OrderID        int              `json:"order_id,omitempty"`
+	ID             int64              `json:"id,omitempty"`
+	OrderID        int64              `json:"order_id,omitempty"`
 	Amount         *decimal.Decimal `json:"amount,omitempty"`
 	Kind           string           `json:"kind,omitempty"`
 	Gateway        string           `json:"gateway,omitempty"`
@@ -246,10 +246,10 @@ type Transaction struct {
 	Test           bool             `json:"test,omitempty"`
 	Authorization  string           `json:"authorization,omitempty"`
 	Currency       string           `json:"currency,omitempty"`
-	LocationID     *int             `json:"location_id,omitempty"`
-	UserID         *int             `json:"user_id,omitempty"`
-	ParentID       *int             `json:"parent_id,omitempty"`
-	DeviceID       *int             `json:"device_id,omitempty"`
+	LocationID     *int64             `json:"location_id,omitempty"`
+	UserID         *int64             `json:"user_id,omitempty"`
+	ParentID       *int64             `json:"parent_id,omitempty"`
+	DeviceID       *int64             `json:"device_id,omitempty"`
 	ErrorCode      string           `json:"error_code,omitempty"`
 	SourceName     string           `json:"source_name,omitempty"`
 	PaymentDetails *PaymentDetails  `json:"payment_details,omitempty"`
@@ -265,20 +265,20 @@ type ClientDetails struct {
 }
 
 type Refund struct {
-	Id              int              `json:"id,omitempty"`
-	OrderId         int              `json:"order_id,omitempty"`
+	Id              int64              `json:"id,omitempty"`
+	OrderId         int64              `json:"order_id,omitempty"`
 	CreatedAt       *time.Time       `json:"created_at,omitempty"`
 	Note            string           `json:"note,omitempty"`
 	Restock         bool             `json:"restock,omitempty"`
-	UserId          int              `json:"user_id,omitempty"`
+	UserId          int64              `json:"user_id,omitempty"`
 	RefundLineItems []RefundLineItem `json:"refund_line_items,omitempty"`
 	Transactions    []Transaction    `json:"transactions,omitempty"`
 }
 
 type RefundLineItem struct {
-	Id         int              `json:"id,omitempty"`
+	Id         int64              `json:"id,omitempty"`
 	Quantity   int              `json:"quantity,omitempty"`
-	LineItemId int              `json:"line_item_id,omitempty"`
+	LineItemId int64              `json:"line_item_id,omitempty"`
 	LineItem   *LineItem        `json:"line_item,omitempty"`
 	Subtotal   *decimal.Decimal `json:"subtotal,omitempty"`
 	TotalTax   *decimal.Decimal `json:"total_tax,omitempty"`
@@ -299,7 +299,7 @@ func (s *OrderServiceOp) Count(options interface{}) (int, error) {
 }
 
 // Get individual order
-func (s *OrderServiceOp) Get(orderID int, options interface{}) (*Order, error) {
+func (s *OrderServiceOp) Get(orderID int64, options interface{}) (*Order, error) {
 	path := fmt.Sprintf("%s/%d.json", ordersBasePath, orderID)
 	resource := new(OrderResource)
 	err := s.client.Get(path, resource, options)
@@ -325,85 +325,85 @@ func (s *OrderServiceOp) Update(order Order) (*Order, error) {
 }
 
 // List metafields for an order
-func (s *OrderServiceOp) ListMetafields(orderID int, options interface{}) ([]Metafield, error) {
+func (s *OrderServiceOp) ListMetafields(orderID int64, options interface{}) ([]Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: ordersResourceName, resourceID: orderID}
 	return metafieldService.List(options)
 }
 
 // Count metafields for an order
-func (s *OrderServiceOp) CountMetafields(orderID int, options interface{}) (int, error) {
+func (s *OrderServiceOp) CountMetafields(orderID int64, options interface{}) (int, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: ordersResourceName, resourceID: orderID}
 	return metafieldService.Count(options)
 }
 
 // Get individual metafield for an order
-func (s *OrderServiceOp) GetMetafield(orderID int, metafieldID int, options interface{}) (*Metafield, error) {
+func (s *OrderServiceOp) GetMetafield(orderID int64, metafieldID int64, options interface{}) (*Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: ordersResourceName, resourceID: orderID}
 	return metafieldService.Get(metafieldID, options)
 }
 
 // Create a new metafield for an order
-func (s *OrderServiceOp) CreateMetafield(orderID int, metafield Metafield) (*Metafield, error) {
+func (s *OrderServiceOp) CreateMetafield(orderID int64, metafield Metafield) (*Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: ordersResourceName, resourceID: orderID}
 	return metafieldService.Create(metafield)
 }
 
 // Update an existing metafield for an order
-func (s *OrderServiceOp) UpdateMetafield(orderID int, metafield Metafield) (*Metafield, error) {
+func (s *OrderServiceOp) UpdateMetafield(orderID int64, metafield Metafield) (*Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: ordersResourceName, resourceID: orderID}
 	return metafieldService.Update(metafield)
 }
 
 // Delete an existing metafield for an order
-func (s *OrderServiceOp) DeleteMetafield(orderID int, metafieldID int) error {
+func (s *OrderServiceOp) DeleteMetafield(orderID int64, metafieldID int64) error {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: ordersResourceName, resourceID: orderID}
 	return metafieldService.Delete(metafieldID)
 }
 
 // List fulfillments for an order
-func (s *OrderServiceOp) ListFulfillments(orderID int, options interface{}) ([]Fulfillment, error) {
+func (s *OrderServiceOp) ListFulfillments(orderID int64, options interface{}) ([]Fulfillment, error) {
 	fulfillmentService := &FulfillmentServiceOp{client: s.client, resource: ordersResourceName, resourceID: orderID}
 	return fulfillmentService.List(options)
 }
 
 // Count fulfillments for an order
-func (s *OrderServiceOp) CountFulfillments(orderID int, options interface{}) (int, error) {
+func (s *OrderServiceOp) CountFulfillments(orderID int64, options interface{}) (int, error) {
 	fulfillmentService := &FulfillmentServiceOp{client: s.client, resource: ordersResourceName, resourceID: orderID}
 	return fulfillmentService.Count(options)
 }
 
 // Get individual fulfillment for an order
-func (s *OrderServiceOp) GetFulfillment(orderID int, fulfillmentID int, options interface{}) (*Fulfillment, error) {
+func (s *OrderServiceOp) GetFulfillment(orderID int64, fulfillmentID int64, options interface{}) (*Fulfillment, error) {
 	fulfillmentService := &FulfillmentServiceOp{client: s.client, resource: ordersResourceName, resourceID: orderID}
 	return fulfillmentService.Get(fulfillmentID, options)
 }
 
 // Create a new fulfillment for an order
-func (s *OrderServiceOp) CreateFulfillment(orderID int, fulfillment Fulfillment) (*Fulfillment, error) {
+func (s *OrderServiceOp) CreateFulfillment(orderID int64, fulfillment Fulfillment) (*Fulfillment, error) {
 	fulfillmentService := &FulfillmentServiceOp{client: s.client, resource: ordersResourceName, resourceID: orderID}
 	return fulfillmentService.Create(fulfillment)
 }
 
 // Update an existing fulfillment for an order
-func (s *OrderServiceOp) UpdateFulfillment(orderID int, fulfillment Fulfillment) (*Fulfillment, error) {
+func (s *OrderServiceOp) UpdateFulfillment(orderID int64, fulfillment Fulfillment) (*Fulfillment, error) {
 	fulfillmentService := &FulfillmentServiceOp{client: s.client, resource: ordersResourceName, resourceID: orderID}
 	return fulfillmentService.Update(fulfillment)
 }
 
 // Complete an existing fulfillment for an order
-func (s *OrderServiceOp) CompleteFulfillment(orderID int, fulfillmentID int) (*Fulfillment, error) {
+func (s *OrderServiceOp) CompleteFulfillment(orderID int64, fulfillmentID int64) (*Fulfillment, error) {
 	fulfillmentService := &FulfillmentServiceOp{client: s.client, resource: ordersResourceName, resourceID: orderID}
 	return fulfillmentService.Complete(fulfillmentID)
 }
 
 // Transition an existing fulfillment for an order
-func (s *OrderServiceOp) TransitionFulfillment(orderID int, fulfillmentID int) (*Fulfillment, error) {
+func (s *OrderServiceOp) TransitionFulfillment(orderID int64, fulfillmentID int64) (*Fulfillment, error) {
 	fulfillmentService := &FulfillmentServiceOp{client: s.client, resource: ordersResourceName, resourceID: orderID}
 	return fulfillmentService.Transition(fulfillmentID)
 }
 
 // Cancel an existing fulfillment for an order
-func (s *OrderServiceOp) CancelFulfillment(orderID int, fulfillmentID int) (*Fulfillment, error) {
+func (s *OrderServiceOp) CancelFulfillment(orderID int64, fulfillmentID int64) (*Fulfillment, error) {
 	fulfillmentService := &FulfillmentServiceOp{client: s.client, resource: ordersResourceName, resourceID: orderID}
 	return fulfillmentService.Cancel(fulfillmentID)
 }

--- a/page.go
+++ b/page.go
@@ -14,10 +14,10 @@ const pagesResourceName = "pages"
 type PageService interface {
 	List(interface{}) ([]Page, error)
 	Count(interface{}) (int, error)
-	Get(int, interface{}) (*Page, error)
+	Get(int64, interface{}) (*Page, error)
 	Create(Page) (*Page, error)
 	Update(Page) (*Page, error)
-	Delete(int) error
+	Delete(int64) error
 
 	// MetafieldsService used for Pages resource to communicate with Metafields
 	// resource
@@ -32,7 +32,7 @@ type PageServiceOp struct {
 
 // Page represents a Shopify page.
 type Page struct {
-	ID             int         `json:"id"`
+	ID             int64         `json:"id"`
 	Author         string      `json:"author"`
 	Handle         string      `json:"handle"`
 	Title          string      `json:"title"`
@@ -41,7 +41,7 @@ type Page struct {
 	BodyHTML       string      `json:"body_html"`
 	TemplateSuffix string      `json:"template_suffix"`
 	PublishedAt    *time.Time  `json:"published_at"`
-	ShopID         int         `json:"shop_id"`
+	ShopID         int64         `json:"shop_id"`
 	Metafields     []Metafield `json:"metafields"`
 }
 
@@ -70,7 +70,7 @@ func (s *PageServiceOp) Count(options interface{}) (int, error) {
 }
 
 // Get individual page
-func (s *PageServiceOp) Get(pageID int, options interface{}) (*Page, error) {
+func (s *PageServiceOp) Get(pageID int64, options interface{}) (*Page, error) {
 	path := fmt.Sprintf("%s/%d.json", pagesBasePath, pageID)
 	resource := new(PageResource)
 	err := s.client.Get(path, resource, options)
@@ -96,42 +96,42 @@ func (s *PageServiceOp) Update(page Page) (*Page, error) {
 }
 
 // Delete an existing page.
-func (s *PageServiceOp) Delete(pageID int) error {
+func (s *PageServiceOp) Delete(pageID int64) error {
 	return s.client.Delete(fmt.Sprintf("%s/%d.json", pagesBasePath, pageID))
 }
 
 // List metafields for a page
-func (s *PageServiceOp) ListMetafields(pageID int, options interface{}) ([]Metafield, error) {
+func (s *PageServiceOp) ListMetafields(pageID int64, options interface{}) ([]Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: pagesResourceName, resourceID: pageID}
 	return metafieldService.List(options)
 }
 
 // Count metafields for a page
-func (s *PageServiceOp) CountMetafields(pageID int, options interface{}) (int, error) {
+func (s *PageServiceOp) CountMetafields(pageID int64, options interface{}) (int, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: pagesResourceName, resourceID: pageID}
 	return metafieldService.Count(options)
 }
 
 // Get individual metafield for a page
-func (s *PageServiceOp) GetMetafield(pageID int, metafieldID int, options interface{}) (*Metafield, error) {
+func (s *PageServiceOp) GetMetafield(pageID int64, metafieldID int64, options interface{}) (*Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: pagesResourceName, resourceID: pageID}
 	return metafieldService.Get(metafieldID, options)
 }
 
 // Create a new metafield for a page
-func (s *PageServiceOp) CreateMetafield(pageID int, metafield Metafield) (*Metafield, error) {
+func (s *PageServiceOp) CreateMetafield(pageID int64, metafield Metafield) (*Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: pagesResourceName, resourceID: pageID}
 	return metafieldService.Create(metafield)
 }
 
 // Update an existing metafield for a page
-func (s *PageServiceOp) UpdateMetafield(pageID int, metafield Metafield) (*Metafield, error) {
+func (s *PageServiceOp) UpdateMetafield(pageID int64, metafield Metafield) (*Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: pagesResourceName, resourceID: pageID}
 	return metafieldService.Update(metafield)
 }
 
 // Delete an existing metafield for a page
-func (s *PageServiceOp) DeleteMetafield(pageID int, metafieldID int) error {
+func (s *PageServiceOp) DeleteMetafield(pageID int64, metafieldID int64) error {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: pagesResourceName, resourceID: pageID}
 	return metafieldService.Delete(metafieldID)
 }

--- a/page.go
+++ b/page.go
@@ -32,7 +32,7 @@ type PageServiceOp struct {
 
 // Page represents a Shopify page.
 type Page struct {
-	ID             int64         `json:"id"`
+	ID             int64       `json:"id"`
 	Author         string      `json:"author"`
 	Handle         string      `json:"handle"`
 	Title          string      `json:"title"`
@@ -41,7 +41,7 @@ type Page struct {
 	BodyHTML       string      `json:"body_html"`
 	TemplateSuffix string      `json:"template_suffix"`
 	PublishedAt    *time.Time  `json:"published_at"`
-	ShopID         int64         `json:"shop_id"`
+	ShopID         int64       `json:"shop_id"`
 	Metafields     []Metafield `json:"metafields"`
 }
 

--- a/page_test.go
+++ b/page_test.go
@@ -10,7 +10,7 @@ import (
 
 func pageTests(t *testing.T, page Page) {
 	// Check that ID is assigned to the returned page
-	expectedInt := 1
+	expectedInt := int64(1)
 	if page.ID != expectedInt {
 		t.Errorf("Page.ID returned %+v, expected %+v", page.ID, expectedInt)
 	}

--- a/product.go
+++ b/product.go
@@ -14,10 +14,10 @@ const productsResourceName = "products"
 type ProductService interface {
 	List(interface{}) ([]Product, error)
 	Count(interface{}) (int, error)
-	Get(int, interface{}) (*Product, error)
+	Get(int64, interface{}) (*Product, error)
 	Create(Product) (*Product, error)
 	Update(Product) (*Product, error)
-	Delete(int) error
+	Delete(int64) error
 
 	// MetafieldsService used for Product resource to communicate with Metafields resource
 	MetafieldsService
@@ -31,7 +31,7 @@ type ProductServiceOp struct {
 
 // Product represents a Shopify product
 type Product struct {
-	ID                             int             `json:"id,omitempty"`
+	ID                             int64           `json:"id,omitempty"`
 	Title                          string          `json:"title,omitempty"`
 	BodyHTML                       string          `json:"body_html,omitempty"`
 	Vendor                         string          `json:"vendor,omitempty"`
@@ -55,8 +55,8 @@ type Product struct {
 
 // The options provided by Shopify
 type ProductOption struct {
-	ID        int      `json:"id,omitempty"`
-	ProductID int      `json:"product_id,omitempty"`
+	ID        int64      `json:"id,omitempty"`
+	ProductID int64      `json:"product_id,omitempty"`
 	Name      string   `json:"name,omitempty"`
 	Position  int      `json:"position,omitempty"`
 	Values    []string `json:"values,omitempty"`
@@ -87,7 +87,7 @@ func (s *ProductServiceOp) Count(options interface{}) (int, error) {
 }
 
 // Get individual product
-func (s *ProductServiceOp) Get(productID int, options interface{}) (*Product, error) {
+func (s *ProductServiceOp) Get(productID int64, options interface{}) (*Product, error) {
 	path := fmt.Sprintf("%s/%d.json", productsBasePath, productID)
 	resource := new(ProductResource)
 	err := s.client.Get(path, resource, options)
@@ -113,42 +113,42 @@ func (s *ProductServiceOp) Update(product Product) (*Product, error) {
 }
 
 // Delete an existing product
-func (s *ProductServiceOp) Delete(productID int) error {
+func (s *ProductServiceOp) Delete(productID int64) error {
 	return s.client.Delete(fmt.Sprintf("%s/%d.json", productsBasePath, productID))
 }
 
 // List metafields for a product
-func (s *ProductServiceOp) ListMetafields(productID int, options interface{}) ([]Metafield, error) {
+func (s *ProductServiceOp) ListMetafields(productID int64, options interface{}) ([]Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: productsResourceName, resourceID: productID}
 	return metafieldService.List(options)
 }
 
 // Count metafields for a product
-func (s *ProductServiceOp) CountMetafields(productID int, options interface{}) (int, error) {
+func (s *ProductServiceOp) CountMetafields(productID int64, options interface{}) (int, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: productsResourceName, resourceID: productID}
 	return metafieldService.Count(options)
 }
 
 // Get individual metafield for a product
-func (s *ProductServiceOp) GetMetafield(productID int, metafieldID int, options interface{}) (*Metafield, error) {
+func (s *ProductServiceOp) GetMetafield(productID int64, metafieldID int64, options interface{}) (*Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: productsResourceName, resourceID: productID}
 	return metafieldService.Get(metafieldID, options)
 }
 
 // Create a new metafield for a product
-func (s *ProductServiceOp) CreateMetafield(productID int, metafield Metafield) (*Metafield, error) {
+func (s *ProductServiceOp) CreateMetafield(productID int64, metafield Metafield) (*Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: productsResourceName, resourceID: productID}
 	return metafieldService.Create(metafield)
 }
 
 // Update an existing metafield for a product
-func (s *ProductServiceOp) UpdateMetafield(productID int, metafield Metafield) (*Metafield, error) {
+func (s *ProductServiceOp) UpdateMetafield(productID int64, metafield Metafield) (*Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: productsResourceName, resourceID: productID}
 	return metafieldService.Update(metafield)
 }
 
 // // Delete an existing metafield for a product
-func (s *ProductServiceOp) DeleteMetafield(productID int, metafieldID int) error {
+func (s *ProductServiceOp) DeleteMetafield(productID int64, metafieldID int64) error {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: productsResourceName, resourceID: productID}
 	return metafieldService.Delete(metafieldID)
 }

--- a/product.go
+++ b/product.go
@@ -55,8 +55,8 @@ type Product struct {
 
 // The options provided by Shopify
 type ProductOption struct {
-	ID        int64      `json:"id,omitempty"`
-	ProductID int64      `json:"product_id,omitempty"`
+	ID        int64    `json:"id,omitempty"`
+	ProductID int64    `json:"product_id,omitempty"`
 	Name      string   `json:"name,omitempty"`
 	Position  int      `json:"position,omitempty"`
 	Values    []string `json:"values,omitempty"`

--- a/product_test.go
+++ b/product_test.go
@@ -10,7 +10,7 @@ import (
 
 func productTests(t *testing.T, product Product) {
 	// Check that ID is assigned to the returned product
-	expectedInt := 1071559748
+	var expectedInt int64 = 1071559748
 	if product.ID != expectedInt {
 		t.Errorf("Product.ID returned %+v, expected %+v", product.ID, expectedInt)
 	}

--- a/product_test.go
+++ b/product_test.go
@@ -45,7 +45,7 @@ func TestProductListFilterByIds(t *testing.T) {
 		params,
 		httpmock.NewStringResponder(200, `{"products": [{"id":1},{"id":2},{"id":3}]}`))
 
-	listOptions := ListOptions{IDs: []int{1, 2, 3}}
+	listOptions := ListOptions{IDs: []int64{1, 2, 3}}
 
 	products, err := client.Product.List(listOptions)
 	if err != nil {

--- a/recurringapplicationcharge.go
+++ b/recurringapplicationcharge.go
@@ -15,11 +15,11 @@ const recurringApplicationChargesBasePath = "admin/recurring_application_charges
 // See https://help.shopify.com/api/reference/billing/recurringapplicationcharge
 type RecurringApplicationChargeService interface {
 	Create(RecurringApplicationCharge) (*RecurringApplicationCharge, error)
-	Get(int, interface{}) (*RecurringApplicationCharge, error)
+	Get(int64, interface{}) (*RecurringApplicationCharge, error)
 	List(interface{}) ([]RecurringApplicationCharge, error)
 	Activate(RecurringApplicationCharge) (*RecurringApplicationCharge, error)
-	Delete(int) error
-	Update(int, int) (*RecurringApplicationCharge, error)
+	Delete(int64) error
+	Update(int64, int64) (*RecurringApplicationCharge, error)
 }
 
 // RecurringApplicationChargeServiceOp handles communication with the
@@ -40,7 +40,7 @@ type RecurringApplicationCharge struct {
 	ConfirmationURL       string           `json:"confirmation_url"`
 	CreatedAt             *time.Time       `json:"created_at"`
 	DecoratedReturnURL    string           `json:"decorated_return_url"`
-	ID                    int              `json:"id"`
+	ID                    int64              `json:"id"`
 	Name                  string           `json:"name"`
 	Price                 *decimal.Decimal `json:"price"`
 	ReturnURL             string           `json:"return_url"`
@@ -136,7 +136,7 @@ func (r *RecurringApplicationChargeServiceOp) Create(charge RecurringApplication
 }
 
 // Get gets individual recurring application charge.
-func (r *RecurringApplicationChargeServiceOp) Get(chargeID int, options interface{}) (
+func (r *RecurringApplicationChargeServiceOp) Get(chargeID int64, options interface{}) (
 	*RecurringApplicationCharge, error) {
 
 	path := fmt.Sprintf("%s/%d.json", recurringApplicationChargesBasePath, chargeID)
@@ -167,12 +167,12 @@ func (r *RecurringApplicationChargeServiceOp) Activate(charge RecurringApplicati
 }
 
 // Delete deletes recurring application charge.
-func (r *RecurringApplicationChargeServiceOp) Delete(chargeID int) error {
+func (r *RecurringApplicationChargeServiceOp) Delete(chargeID int64) error {
 	return r.client.Delete(fmt.Sprintf("%s/%d.json", recurringApplicationChargesBasePath, chargeID))
 }
 
 // Update updates recurring application charge.
-func (r *RecurringApplicationChargeServiceOp) Update(chargeID, newCappedAmount int) (
+func (r *RecurringApplicationChargeServiceOp) Update(chargeID, newCappedAmount int64) (
 	*RecurringApplicationCharge, error) {
 
 	path := fmt.Sprintf("%s/%d/customize.json?recurring_application_charge[capped_amount]=%d",

--- a/recurringapplicationcharge.go
+++ b/recurringapplicationcharge.go
@@ -30,7 +30,7 @@ type RecurringApplicationChargeServiceOp struct {
 
 // RecurringApplicationCharge represents a Shopify RecurringApplicationCharge.
 type RecurringApplicationCharge struct {
-	APIClientID           int              `json:"api_client_id"`
+	APIClientID           int64              `json:"api_client_id"`
 	ActivatedOn           *time.Time       `json:"activated_on"`
 	BalanceRemaining      *decimal.Decimal `json:"balance_remaining"`
 	BalanceUsed           *decimal.Decimal `json:"balance_used"`

--- a/recurringapplicationcharge.go
+++ b/recurringapplicationcharge.go
@@ -40,7 +40,7 @@ type RecurringApplicationCharge struct {
 	ConfirmationURL       string           `json:"confirmation_url"`
 	CreatedAt             *time.Time       `json:"created_at"`
 	DecoratedReturnURL    string           `json:"decorated_return_url"`
-	ID                    int64              `json:"id"`
+	ID                    int64            `json:"id"`
 	Name                  string           `json:"name"`
 	Price                 *decimal.Decimal `json:"price"`
 	ReturnURL             string           `json:"return_url"`

--- a/recurringapplicationcharge_test.go
+++ b/recurringapplicationcharge_test.go
@@ -23,7 +23,7 @@ func recurringApplicationChargeTests(t *testing.T, charge RecurringApplicationCh
 	}{
 		{"ID", int64(1029266948), charge.ID},
 		{"Name", "Super Duper Plan", charge.Name},
-		{"APIClientID", 755357713, charge.APIClientID},
+		{"APIClientID", int64(755357713), charge.APIClientID},
 		{"Price", decimal.NewFromFloat(10.00).String(), charge.Price.String()},
 		{"Status", "pending", charge.Status},
 		{"ReturnURL", "http://super-duper.shopifyapps.com/", charge.ReturnURL},
@@ -71,7 +71,7 @@ func recurringApplicationChargeTestsAllFieldsAffected(t *testing.T,
 	}{
 		{"ID", int64(1029266948), charge.ID},
 		{"Name", "Super Duper Plan", charge.Name},
-		{"APIClientID", 755357713, charge.APIClientID},
+		{"APIClientID", int64(755357713), charge.APIClientID},
 		{"Price", decimal.NewFromFloat(10.00).String(), charge.Price.String()},
 		{"Status", "pending", charge.Status},
 		{"ReturnURL", "http://super-duper.shopifyapps.com/", charge.ReturnURL},

--- a/recurringapplicationcharge_test.go
+++ b/recurringapplicationcharge_test.go
@@ -21,7 +21,7 @@ func recurringApplicationChargeTests(t *testing.T, charge RecurringApplicationCh
 		expected interface{}
 		actual   interface{}
 	}{
-		{"ID", 1029266948, charge.ID},
+		{"ID", int64(1029266948), charge.ID},
 		{"Name", "Super Duper Plan", charge.Name},
 		{"APIClientID", 755357713, charge.APIClientID},
 		{"Price", decimal.NewFromFloat(10.00).String(), charge.Price.String()},
@@ -69,7 +69,7 @@ func recurringApplicationChargeTestsAllFieldsAffected(t *testing.T,
 		expected interface{}
 		actual   interface{}
 	}{
-		{"ID", 1029266948, charge.ID},
+		{"ID", int64(1029266948), charge.ID},
 		{"Name", "Super Duper Plan", charge.Name},
 		{"APIClientID", 755357713, charge.APIClientID},
 		{"Price", decimal.NewFromFloat(10.00).String(), charge.Price.String()},

--- a/redirect.go
+++ b/redirect.go
@@ -26,7 +26,7 @@ type RedirectServiceOp struct {
 
 // Redirect represents a Shopify redirect.
 type Redirect struct {
-	ID     int64    `json:"id"`
+	ID     int64  `json:"id"`
 	Path   string `json:"path"`
 	Target string `json:"target"`
 }

--- a/redirect.go
+++ b/redirect.go
@@ -12,10 +12,10 @@ const redirectsBasePath = "admin/redirects"
 type RedirectService interface {
 	List(interface{}) ([]Redirect, error)
 	Count(interface{}) (int, error)
-	Get(int, interface{}) (*Redirect, error)
+	Get(int64, interface{}) (*Redirect, error)
 	Create(Redirect) (*Redirect, error)
 	Update(Redirect) (*Redirect, error)
-	Delete(int) error
+	Delete(int64) error
 }
 
 // RedirectServiceOp handles communication with the redirect related methods of the
@@ -26,7 +26,7 @@ type RedirectServiceOp struct {
 
 // Redirect represents a Shopify redirect.
 type Redirect struct {
-	ID     int    `json:"id"`
+	ID     int64    `json:"id"`
 	Path   string `json:"path"`
 	Target string `json:"target"`
 }
@@ -56,7 +56,7 @@ func (s *RedirectServiceOp) Count(options interface{}) (int, error) {
 }
 
 // Get individual redirect
-func (s *RedirectServiceOp) Get(redirectID int, options interface{}) (*Redirect, error) {
+func (s *RedirectServiceOp) Get(redirectID int64, options interface{}) (*Redirect, error) {
 	path := fmt.Sprintf("%s/%d.json", redirectsBasePath, redirectID)
 	resource := new(RedirectResource)
 	err := s.client.Get(path, resource, options)
@@ -82,6 +82,6 @@ func (s *RedirectServiceOp) Update(redirect Redirect) (*Redirect, error) {
 }
 
 // Delete an existing redirect.
-func (s *RedirectServiceOp) Delete(redirectID int) error {
+func (s *RedirectServiceOp) Delete(redirectID int64) error {
 	return s.client.Delete(fmt.Sprintf("%s/%d.json", redirectsBasePath, redirectID))
 }

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -10,7 +10,7 @@ import (
 
 func redirectTests(t *testing.T, redirect Redirect) {
 	// Check that ID is assigned to the returned redirect
-	expectedInt := 1
+	expectedInt := int64(1)
 	if redirect.ID != expectedInt {
 		t.Errorf("Redirect.ID returned %+v, expected %+v", redirect.ID, expectedInt)
 	}

--- a/scripttag.go
+++ b/scripttag.go
@@ -13,10 +13,10 @@ const scriptTagsBasePath = "admin/script_tags"
 type ScriptTagService interface {
 	List(interface{}) ([]ScriptTag, error)
 	Count(interface{}) (int, error)
-	Get(int, interface{}) (*ScriptTag, error)
+	Get(int64, interface{}) (*ScriptTag, error)
 	Create(ScriptTag) (*ScriptTag, error)
 	Update(ScriptTag) (*ScriptTag, error)
-	Delete(int) error
+	Delete(int64) error
 }
 
 // ScriptTagServiceOp handles communication with the shop related methods of the
@@ -29,7 +29,7 @@ type ScriptTagServiceOp struct {
 type ScriptTag struct {
 	CreatedAt    *time.Time `json:"created_at"`
 	Event        string     `json:"event"`
-	ID           int        `json:"id"`
+	ID           int64        `json:"id"`
 	Src          string     `json:"src"`
 	DisplayScope string     `json:"display_scope"`
 	UpdatedAt    *time.Time `json:"updated_at"`
@@ -39,7 +39,7 @@ type ScriptTag struct {
 type ScriptTagOption struct {
 	Limit        int       `url:"limit,omitempty"`
 	Page         int       `url:"page,omitempty"`
-	SinceID      int       `url:"since_id,omitempty"`
+	SinceID      int64       `url:"since_id,omitempty"`
 	CreatedAtMin time.Time `url:"created_at_min,omitempty"`
 	CreatedAtMax time.Time `url:"created_at_max,omitempty"`
 	UpdatedAtMin time.Time `url:"updated_at_min,omitempty"`
@@ -75,7 +75,7 @@ func (s *ScriptTagServiceOp) Count(options interface{}) (int, error) {
 }
 
 // Get individual script tag
-func (s *ScriptTagServiceOp) Get(tagID int, options interface{}) (*ScriptTag, error) {
+func (s *ScriptTagServiceOp) Get(tagID int64, options interface{}) (*ScriptTag, error) {
 	path := fmt.Sprintf("%s/%d.json", scriptTagsBasePath, tagID)
 	resource := &ScriptTagResource{}
 	err := s.client.Get(path, resource, options)
@@ -101,6 +101,6 @@ func (s *ScriptTagServiceOp) Update(tag ScriptTag) (*ScriptTag, error) {
 }
 
 // Delete an existing script tag
-func (s *ScriptTagServiceOp) Delete(tagID int) error {
+func (s *ScriptTagServiceOp) Delete(tagID int64) error {
 	return s.client.Delete(fmt.Sprintf("%s/%d.json", scriptTagsBasePath, tagID))
 }

--- a/scripttag.go
+++ b/scripttag.go
@@ -29,7 +29,7 @@ type ScriptTagServiceOp struct {
 type ScriptTag struct {
 	CreatedAt    *time.Time `json:"created_at"`
 	Event        string     `json:"event"`
-	ID           int64        `json:"id"`
+	ID           int64      `json:"id"`
 	Src          string     `json:"src"`
 	DisplayScope string     `json:"display_scope"`
 	UpdatedAt    *time.Time `json:"updated_at"`
@@ -39,7 +39,7 @@ type ScriptTag struct {
 type ScriptTagOption struct {
 	Limit        int       `url:"limit,omitempty"`
 	Page         int       `url:"page,omitempty"`
-	SinceID      int64       `url:"since_id,omitempty"`
+	SinceID      int64     `url:"since_id,omitempty"`
 	CreatedAtMin time.Time `url:"created_at_min,omitempty"`
 	CreatedAtMax time.Time `url:"created_at_max,omitempty"`
 	UpdatedAtMin time.Time `url:"updated_at_min,omitempty"`

--- a/scripttag_test.go
+++ b/scripttag_test.go
@@ -62,7 +62,7 @@ func TestScriptTagGet(t *testing.T) {
 }
 
 func scriptTagTests(t *testing.T, tag ScriptTag) {
-	expected := 870402688
+	expected := int64(870402688)
 	if tag.ID != expected {
 		t.Errorf("tag.ID is %+v, expected %+v", tag.ID, expected)
 	}

--- a/shop.go
+++ b/shop.go
@@ -17,7 +17,7 @@ type ShopServiceOp struct {
 
 // Shop represents a Shopify shop
 type Shop struct {
-	ID                              int        `json:"id"`
+	ID                              int64        `json:"id"`
 	Name                            string     `json:"name"`
 	ShopOwner                       string     `json:"shop_owner"`
 	Email                           string     `json:"email"`
@@ -46,7 +46,7 @@ type Shop struct {
 	PlanDisplayName                 string     `json:"plan_display_name"`
 	PasswordEnabled                 bool       `json:"password_enabled"`
 	PrimaryLocale                   string     `json:"primary_locale"`
-	PrimaryLocationId               int        `json:"primary_location_id"`
+	PrimaryLocationId               int64        `json:"primary_location_id"`
 	Timezone                        string     `json:"timezone"`
 	IanaTimezone                    string     `json:"iana_timezone"`
 	ForceSSL                        bool       `json:"force_ssl"`

--- a/shop.go
+++ b/shop.go
@@ -17,7 +17,7 @@ type ShopServiceOp struct {
 
 // Shop represents a Shopify shop
 type Shop struct {
-	ID                              int64        `json:"id"`
+	ID                              int64      `json:"id"`
 	Name                            string     `json:"name"`
 	ShopOwner                       string     `json:"shop_owner"`
 	Email                           string     `json:"email"`
@@ -46,7 +46,7 @@ type Shop struct {
 	PlanDisplayName                 string     `json:"plan_display_name"`
 	PasswordEnabled                 bool       `json:"password_enabled"`
 	PrimaryLocale                   string     `json:"primary_locale"`
-	PrimaryLocationId               int64        `json:"primary_location_id"`
+	PrimaryLocationId               int64      `json:"primary_location_id"`
 	Timezone                        string     `json:"timezone"`
 	IanaTimezone                    string     `json:"iana_timezone"`
 	ForceSSL                        bool       `json:"force_ssl"`

--- a/shop_test.go
+++ b/shop_test.go
@@ -31,7 +31,7 @@ func TestShopGet(t *testing.T) {
 		expected interface{}
 		actual   interface{}
 	}{
-		{"ID", 690933842, shop.ID},
+		{"ID", int64(690933842), shop.ID},
 		{"ShopOwner", "Steve Jobs", shop.ShopOwner},
 		{"Address1", "1 Infinite Loop", shop.Address1},
 		{"Name", "Apple Computers", shop.Name},

--- a/smartcollection.go
+++ b/smartcollection.go
@@ -37,7 +37,7 @@ type Rule struct {
 
 // SmartCollection represents a Shopify smart collection.
 type SmartCollection struct {
-	ID             int64         `json:"id"`
+	ID             int64       `json:"id"`
 	Handle         string      `json:"handle"`
 	Title          string      `json:"title"`
 	UpdatedAt      *time.Time  `json:"updated_at"`

--- a/smartcollection.go
+++ b/smartcollection.go
@@ -14,10 +14,10 @@ const smartCollectionsResourceName = "collections"
 type SmartCollectionService interface {
 	List(interface{}) ([]SmartCollection, error)
 	Count(interface{}) (int, error)
-	Get(int, interface{}) (*SmartCollection, error)
+	Get(int64, interface{}) (*SmartCollection, error)
 	Create(SmartCollection) (*SmartCollection, error)
 	Update(SmartCollection) (*SmartCollection, error)
-	Delete(int) error
+	Delete(int64) error
 
 	// MetafieldsService used for SmartCollection resource to communicate with Metafields resource
 	MetafieldsService
@@ -37,7 +37,7 @@ type Rule struct {
 
 // SmartCollection represents a Shopify smart collection.
 type SmartCollection struct {
-	ID             int         `json:"id"`
+	ID             int64         `json:"id"`
 	Handle         string      `json:"handle"`
 	Title          string      `json:"title"`
 	UpdatedAt      *time.Time  `json:"updated_at"`
@@ -78,7 +78,7 @@ func (s *SmartCollectionServiceOp) Count(options interface{}) (int, error) {
 }
 
 // Get individual smart collection
-func (s *SmartCollectionServiceOp) Get(collectionID int, options interface{}) (*SmartCollection, error) {
+func (s *SmartCollectionServiceOp) Get(collectionID int64, options interface{}) (*SmartCollection, error) {
 	path := fmt.Sprintf("%s/%d.json", smartCollectionsBasePath, collectionID)
 	resource := new(SmartCollectionResource)
 	err := s.client.Get(path, resource, options)
@@ -105,42 +105,42 @@ func (s *SmartCollectionServiceOp) Update(collection SmartCollection) (*SmartCol
 }
 
 // Delete an existing smart collection.
-func (s *SmartCollectionServiceOp) Delete(collectionID int) error {
+func (s *SmartCollectionServiceOp) Delete(collectionID int64) error {
 	return s.client.Delete(fmt.Sprintf("%s/%d.json", smartCollectionsBasePath, collectionID))
 }
 
 // List metafields for a smart collection
-func (s *SmartCollectionServiceOp) ListMetafields(smartCollectionID int, options interface{}) ([]Metafield, error) {
+func (s *SmartCollectionServiceOp) ListMetafields(smartCollectionID int64, options interface{}) ([]Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: smartCollectionsResourceName, resourceID: smartCollectionID}
 	return metafieldService.List(options)
 }
 
 // Count metafields for a smart collection
-func (s *SmartCollectionServiceOp) CountMetafields(smartCollectionID int, options interface{}) (int, error) {
+func (s *SmartCollectionServiceOp) CountMetafields(smartCollectionID int64, options interface{}) (int, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: smartCollectionsResourceName, resourceID: smartCollectionID}
 	return metafieldService.Count(options)
 }
 
 // Get individual metafield for a smart collection
-func (s *SmartCollectionServiceOp) GetMetafield(smartCollectionID int, metafieldID int, options interface{}) (*Metafield, error) {
+func (s *SmartCollectionServiceOp) GetMetafield(smartCollectionID int64, metafieldID int64, options interface{}) (*Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: smartCollectionsResourceName, resourceID: smartCollectionID}
 	return metafieldService.Get(metafieldID, options)
 }
 
 // Create a new metafield for a smart collection
-func (s *SmartCollectionServiceOp) CreateMetafield(smartCollectionID int, metafield Metafield) (*Metafield, error) {
+func (s *SmartCollectionServiceOp) CreateMetafield(smartCollectionID int64, metafield Metafield) (*Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: smartCollectionsResourceName, resourceID: smartCollectionID}
 	return metafieldService.Create(metafield)
 }
 
 // Update an existing metafield for a smart collection
-func (s *SmartCollectionServiceOp) UpdateMetafield(smartCollectionID int, metafield Metafield) (*Metafield, error) {
+func (s *SmartCollectionServiceOp) UpdateMetafield(smartCollectionID int64, metafield Metafield) (*Metafield, error) {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: smartCollectionsResourceName, resourceID: smartCollectionID}
 	return metafieldService.Update(metafield)
 }
 
 // // Delete an existing metafield for a smart collection
-func (s *SmartCollectionServiceOp) DeleteMetafield(smartCollectionID int, metafieldID int) error {
+func (s *SmartCollectionServiceOp) DeleteMetafield(smartCollectionID int64, metafieldID int64) error {
 	metafieldService := &MetafieldServiceOp{client: s.client, resource: smartCollectionsResourceName, resourceID: smartCollectionID}
 	return metafieldService.Delete(metafieldID)
 }

--- a/smartcollection_test.go
+++ b/smartcollection_test.go
@@ -15,7 +15,7 @@ func smartCollectionTests(t *testing.T, collection SmartCollection) {
 		expected interface{}
 		actual   interface{}
 	}{
-		{"ID", 30497275952, collection.ID},
+		{"ID", int64(30497275952), collection.ID},
 		{"Handle", "macbooks", collection.Handle},
 		{"Title", "Macbooks", collection.Title},
 		{"BodyHTML", "Macbook Body", collection.BodyHTML},

--- a/storefrontaccesstoken.go
+++ b/storefrontaccesstoken.go
@@ -24,7 +24,7 @@ type StorefrontAccessTokenServiceOp struct {
 
 // StorefrontAccessToken represents a Shopify storefront access token
 type StorefrontAccessToken struct {
-	ID                int64        `json:"id,omitempty"`
+	ID                int64      `json:"id,omitempty"`
 	Title             string     `json:"title,omitempty"`
 	AccessToken       string     `json:"access_token,omitempty"`
 	AccessScope       string     `json:"access_scope,omitempty"`

--- a/storefrontaccesstoken.go
+++ b/storefrontaccesstoken.go
@@ -13,7 +13,7 @@ const storefrontAccessTokensBasePath = "admin/storefront_access_tokens"
 type StorefrontAccessTokenService interface {
 	List(interface{}) ([]StorefrontAccessToken, error)
 	Create(StorefrontAccessToken) (*StorefrontAccessToken, error)
-	Delete(int) error
+	Delete(int64) error
 }
 
 // StorefrontAccessTokenServiceOp handles communication with the storefront access token
@@ -24,7 +24,7 @@ type StorefrontAccessTokenServiceOp struct {
 
 // StorefrontAccessToken represents a Shopify storefront access token
 type StorefrontAccessToken struct {
-	ID                int        `json:"id,omitempty"`
+	ID                int64        `json:"id,omitempty"`
 	Title             string     `json:"title,omitempty"`
 	AccessToken       string     `json:"access_token,omitempty"`
 	AccessScope       string     `json:"access_scope,omitempty"`
@@ -60,6 +60,6 @@ func (s *StorefrontAccessTokenServiceOp) Create(storefrontAccessToken Storefront
 }
 
 // Delete an existing storefront access token
-func (s *StorefrontAccessTokenServiceOp) Delete(ID int) error {
+func (s *StorefrontAccessTokenServiceOp) Delete(ID int64) error {
 	return s.client.Delete(fmt.Sprintf("%s/%d.json", storefrontAccessTokensBasePath, ID))
 }

--- a/theme.go
+++ b/theme.go
@@ -28,12 +28,12 @@ type ThemeServiceOp struct {
 
 // Theme represents a Shopify theme
 type Theme struct {
-	ID           int        `json:"id"`
+	ID           int64        `json:"id"`
 	Name         string     `json:"name"`
 	Previewable  bool       `json:"previewable"`
 	Processing   bool       `json:"processing"`
 	Role         string     `json:"role"`
-	ThemeStoreID int        `json:"theme_store_id"`
+	ThemeStoreID int64        `json:"theme_store_id"`
 	CreatedAt    *time.Time `json:"created_at"`
 	UpdatedAt    *time.Time `json:"updated_at"`
 }

--- a/theme.go
+++ b/theme.go
@@ -28,12 +28,12 @@ type ThemeServiceOp struct {
 
 // Theme represents a Shopify theme
 type Theme struct {
-	ID           int64        `json:"id"`
+	ID           int64      `json:"id"`
 	Name         string     `json:"name"`
 	Previewable  bool       `json:"previewable"`
 	Processing   bool       `json:"processing"`
 	Role         string     `json:"role"`
-	ThemeStoreID int64        `json:"theme_store_id"`
+	ThemeStoreID int64      `json:"theme_store_id"`
 	CreatedAt    *time.Time `json:"created_at"`
 	UpdatedAt    *time.Time `json:"updated_at"`
 }

--- a/transaction.go
+++ b/transaction.go
@@ -6,10 +6,10 @@ import "fmt"
 // the Shopify API.
 // See: https://help.shopify.com/api/reference/transaction
 type TransactionService interface {
-	List(int, interface{}) ([]Transaction, error)
-	Count(int, interface{}) (int, error)
-	Get(int, int, interface{}) (*Transaction, error)
-	Create(int, Transaction) (*Transaction, error)
+	List(int64, interface{}) ([]Transaction, error)
+	Count(int64, interface{}) (int, error)
+	Get(int64, int64, interface{}) (*Transaction, error)
+	Create(int64, Transaction) (*Transaction, error)
 }
 
 // TransactionServiceOp handles communication with the transaction related methods of the
@@ -29,7 +29,7 @@ type TransactionsResource struct {
 }
 
 // List transactions
-func (s *TransactionServiceOp) List(orderID int, options interface{}) ([]Transaction, error) {
+func (s *TransactionServiceOp) List(orderID int64, options interface{}) ([]Transaction, error) {
 	path := fmt.Sprintf("%s/%d/transactions.json", ordersBasePath, orderID)
 	resource := new(TransactionsResource)
 	err := s.client.Get(path, resource, options)
@@ -37,13 +37,13 @@ func (s *TransactionServiceOp) List(orderID int, options interface{}) ([]Transac
 }
 
 // Count transactions
-func (s *TransactionServiceOp) Count(orderID int, options interface{}) (int, error) {
+func (s *TransactionServiceOp) Count(orderID int64, options interface{}) (int, error) {
 	path := fmt.Sprintf("%s/%d/transactions/count.json", ordersBasePath, orderID)
 	return s.client.Count(path, options)
 }
 
 // Get individual transaction
-func (s *TransactionServiceOp) Get(orderID int, transactionID int, options interface{}) (*Transaction, error) {
+func (s *TransactionServiceOp) Get(orderID int64, transactionID int64, options interface{}) (*Transaction, error) {
 	path := fmt.Sprintf("%s/%d/transactions/%d.json", ordersBasePath, orderID, transactionID)
 	resource := new(TransactionResource)
 	err := s.client.Get(path, resource, options)
@@ -51,7 +51,7 @@ func (s *TransactionServiceOp) Get(orderID int, transactionID int, options inter
 }
 
 // Create a new transaction
-func (s *TransactionServiceOp) Create(orderID int, transaction Transaction) (*Transaction, error) {
+func (s *TransactionServiceOp) Create(orderID int64, transaction Transaction) (*Transaction, error) {
 	path := fmt.Sprintf("%s/%d/transactions.json", ordersBasePath, orderID)
 	wrappedData := TransactionResource{Transaction: &transaction}
 	resource := new(TransactionResource)

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -76,25 +76,25 @@ func TransactionTests(t *testing.T, transaction Transaction) {
 	}
 
 	// Check that the LocationID value is assigned to the returned transaction
-	var expectedLocationID *int
+	var expectedLocationID *int64
 	if transaction.LocationID != expectedLocationID {
 		t.Errorf("Transaction.LocationID returned %+v, expected %+v", transaction.LocationID, expectedLocationID)
 	}
 
 	// Check that the UserID value is assigned to the returned transaction
-	var expectedUserID *int
+	var expectedUserID *int64
 	if transaction.UserID != expectedUserID {
 		t.Errorf("Transaction.UserID returned %+v, expected %+v", transaction.UserID, expectedUserID)
 	}
 
 	// Check that the ParentID value is assigned to the returned transaction
-	var expectedParentID *int
+	var expectedParentID *int64
 	if transaction.ParentID != expectedParentID {
 		t.Errorf("Transaction.ParentID returned %+v, expected %+v", transaction.ParentID, expectedParentID)
 	}
 
 	// Check that the DeviceID value is assigned to the returned transaction
-	var expectedDeviceID *int
+	var expectedDeviceID *int64
 	if transaction.DeviceID != expectedDeviceID {
 		t.Errorf("Transacion.DeviceID returned %+v, expected %+v", transaction.DeviceID, expectedDeviceID)
 	}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -10,13 +10,13 @@ import (
 
 func TransactionTests(t *testing.T, transaction Transaction) {
 	// Check that the ID is assigned to the returned transaction
-	expectedID := 389404469
+	expectedID := int64(389404469)
 	if transaction.ID != expectedID {
 		t.Errorf("Transaction.ID returned %+v, expected %+v", transaction.ID, expectedID)
 	}
 
 	// Check that the OrderID value is assigned to the returned transaction
-	expectedOrderID := 450789469
+	expectedOrderID := int64(450789469)
 	if transaction.OrderID != expectedOrderID {
 		t.Errorf("Transaction.OrderID returned %+v, expected %+v", transaction.OrderID, expectedOrderID)
 	}

--- a/usagecharge.go
+++ b/usagecharge.go
@@ -32,7 +32,7 @@ type UsageCharge struct {
 	BillingOn        *time.Time       `json:"billing_on,omitempty"`
 	CreatedAt        *time.Time       `json:"created_at,omitempty"`
 	Description      string           `json:"description,omitempty"`
-	ID               int64              `json:"id,omitempty"`
+	ID               int64            `json:"id,omitempty"`
 	Price            *decimal.Decimal `json:"price,omitempty"`
 	RiskLevel        *decimal.Decimal `json:"risk_level,omitempty"`
 }

--- a/usagecharge.go
+++ b/usagecharge.go
@@ -14,9 +14,9 @@ const usageChargesPath = "usage_charges"
 // UsageCharge endpoints of the Shopify API.
 // See https://help.shopify.com/en/api/reference/billing/usagecharge#endpoints
 type UsageChargeService interface {
-	Create(int, UsageCharge) (*UsageCharge, error)
-	Get(int, int, interface{}) (*UsageCharge, error)
-	List(int, interface{}) ([]UsageCharge, error)
+	Create(int64, UsageCharge) (*UsageCharge, error)
+	Get(int64, int64, interface{}) (*UsageCharge, error)
+	List(int64, interface{}) ([]UsageCharge, error)
 }
 
 // UsageChargeServiceOp handles communication with the
@@ -32,7 +32,7 @@ type UsageCharge struct {
 	BillingOn        *time.Time       `json:"billing_on,omitempty"`
 	CreatedAt        *time.Time       `json:"created_at,omitempty"`
 	Description      string           `json:"description,omitempty"`
-	ID               int              `json:"id,omitempty"`
+	ID               int64              `json:"id,omitempty"`
 	Price            *decimal.Decimal `json:"price,omitempty"`
 	RiskLevel        *decimal.Decimal `json:"risk_level,omitempty"`
 }
@@ -70,7 +70,7 @@ type UsageChargesResource struct {
 }
 
 // Create creates new usage charge given a recurring charge. *required fields: price and description
-func (r *UsageChargeServiceOp) Create(chargeID int, usageCharge UsageCharge) (
+func (r *UsageChargeServiceOp) Create(chargeID int64, usageCharge UsageCharge) (
 	*UsageCharge, error) {
 
 	path := fmt.Sprintf("%s/%d/%s.json", recurringApplicationChargesBasePath, chargeID, usageChargesPath)
@@ -81,7 +81,7 @@ func (r *UsageChargeServiceOp) Create(chargeID int, usageCharge UsageCharge) (
 }
 
 // Get gets individual usage charge.
-func (r *UsageChargeServiceOp) Get(chargeID int, usageChargeID int, options interface{}) (
+func (r *UsageChargeServiceOp) Get(chargeID int64, usageChargeID int64, options interface{}) (
 	*UsageCharge, error) {
 
 	path := fmt.Sprintf("%s/%d/%s/%d.json", recurringApplicationChargesBasePath, chargeID, usageChargesPath, usageChargeID)
@@ -91,7 +91,7 @@ func (r *UsageChargeServiceOp) Get(chargeID int, usageChargeID int, options inte
 }
 
 // List gets all usage charges associated with the recurring charge.
-func (r *UsageChargeServiceOp) List(chargeID int, options interface{}) (
+func (r *UsageChargeServiceOp) List(chargeID int64, options interface{}) (
 	[]UsageCharge, error) {
 
 	path := fmt.Sprintf("%s/%d/%s.json", recurringApplicationChargesBasePath, chargeID, usageChargesPath)

--- a/util.go
+++ b/util.go
@@ -30,7 +30,7 @@ func ShopBaseUrl(name string) string {
 }
 
 // Return the prefix for a metafield path
-func MetafieldPathPrefix(resource string, resourceID int) string {
+func MetafieldPathPrefix(resource string, resourceID int64) string {
 	var prefix string
 	if resource == "" {
 		prefix = fmt.Sprintf("admin/metafields")
@@ -41,7 +41,7 @@ func MetafieldPathPrefix(resource string, resourceID int) string {
 }
 
 // Return the prefix for a fulfillment path
-func FulfillmentPathPrefix(resource string, resourceID int) string {
+func FulfillmentPathPrefix(resource string, resourceID int64) string {
 	var prefix string
 	if resource == "" {
 		prefix = fmt.Sprintf("admin/fulfillments")

--- a/util_test.go
+++ b/util_test.go
@@ -66,7 +66,7 @@ func TestShopBaseUrl(t *testing.T) {
 func TestMetafieldPathPrefix(t *testing.T) {
 	cases := []struct {
 		resource   string
-		resourceID int
+		resourceID int64
 		expected   string
 	}{
 		{"", 0, "admin/metafields"},
@@ -84,7 +84,7 @@ func TestMetafieldPathPrefix(t *testing.T) {
 func TestFulfillmentPathPrefix(t *testing.T) {
 	cases := []struct {
 		resource   string
-		resourceID int
+		resourceID int64
 		expected   string
 	}{
 		{"", 0, "admin/fulfillments"},

--- a/variant.go
+++ b/variant.go
@@ -29,8 +29,8 @@ type VariantServiceOp struct {
 
 // Variant represents a Shopify variant
 type Variant struct {
-	ID                   int64              `json:"id,omitempty"`
-	ProductID            int64              `json:"product_id,omitempty"`
+	ID                   int64            `json:"id,omitempty"`
+	ProductID            int64            `json:"product_id,omitempty"`
 	Title                string           `json:"title,omitempty"`
 	Sku                  string           `json:"sku,omitempty"`
 	Position             int              `json:"position,omitempty"`
@@ -40,7 +40,7 @@ type Variant struct {
 	CompareAtPrice       *decimal.Decimal `json:"compare_at_price,omitempty"`
 	FulfillmentService   string           `json:"fulfillment_service,omitempty"`
 	InventoryManagement  string           `json:"inventory_management,omitempty"`
-	InventoryItemId      int64              `json:"inventory_item_id,omitempty"`
+	InventoryItemId      int64            `json:"inventory_item_id,omitempty"`
 	Option1              string           `json:"option1,omitempty"`
 	Option2              string           `json:"option2,omitempty"`
 	Option3              string           `json:"option3,omitempty"`
@@ -48,7 +48,7 @@ type Variant struct {
 	UpdatedAt            *time.Time       `json:"updated_at,omitempty"`
 	Taxable              bool             `json:"taxable,omitempty"`
 	Barcode              string           `json:"barcode,omitempty"`
-	ImageID              int64              `json:"image_id,omitempty"`
+	ImageID              int64            `json:"image_id,omitempty"`
 	InventoryQuantity    int              `json:"inventory_quantity,omitempty"`
 	Weight               *decimal.Decimal `json:"weight,omitempty"`
 	WeightUnit           string           `json:"weight_unit,omitempty"`

--- a/variant.go
+++ b/variant.go
@@ -13,12 +13,12 @@ const variantsBasePath = "admin/variants"
 // of the Shopify API.
 // See https://help.shopify.com/api/reference/product_variant
 type VariantService interface {
-	List(int, interface{}) ([]Variant, error)
-	Count(int, interface{}) (int, error)
-	Get(int, interface{}) (*Variant, error)
-	Create(int, Variant) (*Variant, error)
+	List(int64, interface{}) ([]Variant, error)
+	Count(int64, interface{}) (int, error)
+	Get(int64, interface{}) (*Variant, error)
+	Create(int64, Variant) (*Variant, error)
 	Update(Variant) (*Variant, error)
-	Delete(int, int) error
+	Delete(int64, int64) error
 }
 
 // VariantServiceOp handles communication with the variant related methods of
@@ -29,8 +29,8 @@ type VariantServiceOp struct {
 
 // Variant represents a Shopify variant
 type Variant struct {
-	ID                   int              `json:"id,omitempty"`
-	ProductID            int              `json:"product_id,omitempty"`
+	ID                   int64              `json:"id,omitempty"`
+	ProductID            int64              `json:"product_id,omitempty"`
 	Title                string           `json:"title,omitempty"`
 	Sku                  string           `json:"sku,omitempty"`
 	Position             int              `json:"position,omitempty"`
@@ -40,7 +40,7 @@ type Variant struct {
 	CompareAtPrice       *decimal.Decimal `json:"compare_at_price,omitempty"`
 	FulfillmentService   string           `json:"fulfillment_service,omitempty"`
 	InventoryManagement  string           `json:"inventory_management,omitempty"`
-	InventoryItemId      int              `json:"inventory_item_id,omitempty"`
+	InventoryItemId      int64              `json:"inventory_item_id,omitempty"`
 	Option1              string           `json:"option1,omitempty"`
 	Option2              string           `json:"option2,omitempty"`
 	Option3              string           `json:"option3,omitempty"`
@@ -48,7 +48,7 @@ type Variant struct {
 	UpdatedAt            *time.Time       `json:"updated_at,omitempty"`
 	Taxable              bool             `json:"taxable,omitempty"`
 	Barcode              string           `json:"barcode,omitempty"`
-	ImageID              int              `json:"image_id,omitempty"`
+	ImageID              int64              `json:"image_id,omitempty"`
 	InventoryQuantity    int              `json:"inventory_quantity,omitempty"`
 	Weight               *decimal.Decimal `json:"weight,omitempty"`
 	WeightUnit           string           `json:"weight_unit,omitempty"`
@@ -68,7 +68,7 @@ type VariantsResource struct {
 }
 
 // List variants
-func (s *VariantServiceOp) List(productID int, options interface{}) ([]Variant, error) {
+func (s *VariantServiceOp) List(productID int64, options interface{}) ([]Variant, error) {
 	path := fmt.Sprintf("%s/%d/variants.json", productsBasePath, productID)
 	resource := new(VariantsResource)
 	err := s.client.Get(path, resource, options)
@@ -76,13 +76,13 @@ func (s *VariantServiceOp) List(productID int, options interface{}) ([]Variant, 
 }
 
 // Count variants
-func (s *VariantServiceOp) Count(productID int, options interface{}) (int, error) {
+func (s *VariantServiceOp) Count(productID int64, options interface{}) (int, error) {
 	path := fmt.Sprintf("%s/%d/variants/count.json", productsBasePath, productID)
 	return s.client.Count(path, options)
 }
 
 // Get individual variant
-func (s *VariantServiceOp) Get(variantID int, options interface{}) (*Variant, error) {
+func (s *VariantServiceOp) Get(variantID int64, options interface{}) (*Variant, error) {
 	path := fmt.Sprintf("%s/%d.json", variantsBasePath, variantID)
 	resource := new(VariantResource)
 	err := s.client.Get(path, resource, options)
@@ -90,7 +90,7 @@ func (s *VariantServiceOp) Get(variantID int, options interface{}) (*Variant, er
 }
 
 // Create a new variant
-func (s *VariantServiceOp) Create(productID int, variant Variant) (*Variant, error) {
+func (s *VariantServiceOp) Create(productID int64, variant Variant) (*Variant, error) {
 	path := fmt.Sprintf("%s/%d/variants.json", productsBasePath, productID)
 	wrappedData := VariantResource{Variant: &variant}
 	resource := new(VariantResource)
@@ -108,6 +108,6 @@ func (s *VariantServiceOp) Update(variant Variant) (*Variant, error) {
 }
 
 // Delete an existing product
-func (s *VariantServiceOp) Delete(productID int, variantID int) error {
+func (s *VariantServiceOp) Delete(productID int64, variantID int64) error {
 	return s.client.Delete(fmt.Sprintf("%s/%d/variants/%d.json", productsBasePath, productID, variantID))
 }

--- a/variant_test.go
+++ b/variant_test.go
@@ -11,7 +11,7 @@ import (
 
 func variantTests(t *testing.T, variant Variant) {
 	// Check that the ID is assigned to the returned variant
-	expectedInt := 1
+	expectedInt := int64(1)
 	if variant.ID != expectedInt {
 		t.Errorf("Variant.ID returned %+v, expected %+v", variant.ID, expectedInt)
 	}
@@ -22,7 +22,7 @@ func variantTests(t *testing.T, variant Variant) {
 		t.Errorf("Variant.Title returned %+v, expected %+v", variant.Title, expectedTitle)
 	}
 
-	expectedInventoryItemId := 1
+	expectedInventoryItemId := int64(1)
 	if variant.InventoryItemId != expectedInventoryItemId {
 		t.Errorf("Variant.InventoryItemId returned %+v, expected %+v", variant.InventoryItemId, expectedInventoryItemId)
 	}

--- a/webhook.go
+++ b/webhook.go
@@ -27,7 +27,7 @@ type WebhookServiceOp struct {
 
 // Webhook represents a Shopify webhook
 type Webhook struct {
-	ID                  int64        `json:"id"`
+	ID                  int64      `json:"id"`
 	Address             string     `json:"address"`
 	Topic               string     `json:"topic"`
 	Format              string     `json:"format"`

--- a/webhook.go
+++ b/webhook.go
@@ -13,10 +13,10 @@ const webhooksBasePath = "admin/webhooks"
 type WebhookService interface {
 	List(interface{}) ([]Webhook, error)
 	Count(interface{}) (int, error)
-	Get(int, interface{}) (*Webhook, error)
+	Get(int64, interface{}) (*Webhook, error)
 	Create(Webhook) (*Webhook, error)
 	Update(Webhook) (*Webhook, error)
-	Delete(int) error
+	Delete(int64) error
 }
 
 // WebhookServiceOp handles communication with the webhook-related methods of
@@ -27,7 +27,7 @@ type WebhookServiceOp struct {
 
 // Webhook represents a Shopify webhook
 type Webhook struct {
-	ID                  int        `json:"id"`
+	ID                  int64        `json:"id"`
 	Address             string     `json:"address"`
 	Topic               string     `json:"topic"`
 	Format              string     `json:"format"`
@@ -68,7 +68,7 @@ func (s *WebhookServiceOp) Count(options interface{}) (int, error) {
 }
 
 // Get individual webhook
-func (s *WebhookServiceOp) Get(webhookdID int, options interface{}) (*Webhook, error) {
+func (s *WebhookServiceOp) Get(webhookdID int64, options interface{}) (*Webhook, error) {
 	path := fmt.Sprintf("%s/%d.json", webhooksBasePath, webhookdID)
 	resource := new(WebhookResource)
 	err := s.client.Get(path, resource, options)
@@ -94,6 +94,6 @@ func (s *WebhookServiceOp) Update(webhook Webhook) (*Webhook, error) {
 }
 
 // Delete an existing webhooks
-func (s *WebhookServiceOp) Delete(ID int) error {
+func (s *WebhookServiceOp) Delete(ID int64) error {
 	return s.client.Delete(fmt.Sprintf("%s/%d.json", webhooksBasePath, ID))
 }


### PR DESCRIPTION
I've gone through the project and updated ID types to int64 to match values on the Shopify side.  This is affecting us primarily with Product data, though Variant and InventoryItem are affected as well.  As meta field types needed changing, the update touched nearly everything. 

As part of this I added a Vendor field to the ListOptions, to allow filtering product queries.

I did not change APIClientID seemed unnecessary, though it'd be trivial to do...

test changes were limited to casting constant values, and updates to ID types.  All tests pass.