### PR TITLE
since_id=0 in query params for lists.

### DIFF
--- a/collect_test.go
+++ b/collect_test.go
@@ -71,7 +71,8 @@ func TestCollectCount(t *testing.T) {
 		t.Errorf("Collect.Count returned %d, expected %d", cnt, expected)
 	}
 
-	cnt, err = client.Collect.Count(ListOptions{SinceID: 123})
+	sinceID := int64(123)
+	cnt, err = client.Collect.Count(ListOptions{SinceID: &sinceID})
 	if err != nil {
 		t.Errorf("Collect.Count returned error: %v", err)
 	}

--- a/goshopify.go
+++ b/goshopify.go
@@ -378,7 +378,7 @@ func CheckResponseError(r *http.Response) error {
 type ListOptions struct {
 	Page         int       `url:"page,omitempty"`
 	Limit        int       `url:"limit,omitempty"`
-	SinceID      int64     `url:"since_id,omitempty"`
+	SinceID      *int64    `url:"since_id,omitempty"`
 	CreatedAtMin time.Time `url:"created_at_min,omitempty"`
 	CreatedAtMax time.Time `url:"created_at_max,omitempty"`
 	UpdatedAtMin time.Time `url:"updated_at_min,omitempty"`

--- a/inventory_item_test.go
+++ b/inventory_item_test.go
@@ -38,7 +38,7 @@ func inventoryItemTests(t *testing.T, item *InventoryItem) {
 func inventoryItemsTests(t *testing.T, items []InventoryItem) {
 	expectedLen := 3
 	if len(items) != expectedLen {
-		t.Errorf("InventoryItems list lenth is %+v, expected %+v", len(items), expectedLen)
+		t.Errorf("InventoryItems list length is %+v, expected %+v", len(items), expectedLen)
 	}
 }
 

--- a/product_test.go
+++ b/product_test.go
@@ -34,6 +34,31 @@ func TestProductList(t *testing.T) {
 		t.Errorf("Product.List returned %+v, expected %+v", products, expected)
 	}
 }
+func TestProductListWithZeroSinceID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	params := map[string]string{"since_id": "0"}
+	httpmock.RegisterResponderWithQuery(
+		"GET",
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/products.json", globalApiPathPrefix),
+		params,
+		httpmock.NewStringResponder(200, `{"products": [{"id":1},{"id":2}]}`),
+	)
+
+	zero := int64(0)
+	listOptions := ListOptions{SinceID: &zero}
+
+	products, err := client.Product.List(listOptions)
+	if err != nil {
+		t.Errorf("Product.List returned error: %v", err)
+	}
+
+	expected := []Product{{ID: 1}, {ID: 2}}
+	if !reflect.DeepEqual(products, expected) {
+		t.Errorf("Product.List returned %+v, expected %+v", products, expected)
+	}
+}
 
 func TestProductListFilterByIds(t *testing.T) {
 	setup()


### PR DESCRIPTION
Product list [method](https://help.shopify.com/en/api/reference/products/product#index) has a parameter `since_id` which is used for `since_id` based pagination.  In order to retrieve all products it's necessary to iterate over the product list, changing `since_id` to last product ID from retrieved array.  

In this case for very first request `since_id` should be explicitly set to `0`, otherwise array of returned  products is started from random product. 

Request with explicitly set `since_id`:
`curl https://<creds>@<my-shop-id>.myshopify.com/admin/api/2019-04/products.json?fields=id&since_id=0`
response
```json 
{"products":[
   {"id":1510627409984}, ... ,{"id":3591085817920}
]}
```

Request without `since_id`:
`curl https://<creds>@<my-shop-id>.myshopify.com/admin/api/2019-04/products.json?fields=id`
response
```json 
{"products":[
   {"id":3591061766208}, ... ,{"id":3592731885632}
]}
```

In struct `ListOptions` field [SinceID](https://github.com/bold-commerce/go-shopify/blob/master/goshopify.go#L381) has type `int` and tag with `omitempty` setting.  In this case if `SinceID` is set to `0`  even excplicitly, it will not be added to query string because `0` is default value for `int`. 

This fix changes type of `SinceID` to `*int` which allows to set value to `0` explicitly.




