### PR TITLE
Remove omit_empty from json tag for Fulfillment.NotifyCustomer

### DIFF
--- a/fulfillment.go
+++ b/fulfillment.go
@@ -58,7 +58,7 @@ type Fulfillment struct {
 	TrackingUrls    []string   `json:"tracking_urls,omitempty"`
 	Receipt         Receipt    `json:"receipt,omitempty"`
 	LineItems       []LineItem `json:"line_items,omitempty"`
-	NotifyCustomer  bool       `json:"notify_customer,omitempty"`
+	NotifyCustomer  bool       `json:"notify_customer"`
 }
 
 // Receipt represents a Shopify receipt.


### PR DESCRIPTION
From [Shopify's REST API Doc on Fulfillments](https://help.shopify.com/en/api/reference/shipping-and-fulfillment/fulfillment): 
> `notify_customer`: Whether the customer should be notified. If set to true, then an email will be sent when the fulfillment is created or updated. For orders that were initially created using the API, the default value is false. For all other orders, the default value is true.Whether the customer should be notified. If set to true, then an email will be sent when the fulfillment is created or updated. For orders that were initially created using the API, the default value is false. For all other orders, **the default value is true**.

This PR removes `omitempty` from the JSON tag because it prevents `false` from being sent, and thus the default behavior from being overriden.
