### PR TITLE
fixed can't unpublished product

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 coverage.*
 .vscode
 .idea
+go.mod
+go.sum

--- a/product.go
+++ b/product.go
@@ -39,7 +39,7 @@ type Product struct {
 	Handle                         string          `json:"handle,omitempty"`
 	CreatedAt                      *time.Time      `json:"created_at,omitempty"`
 	UpdatedAt                      *time.Time      `json:"updated_at,omitempty"`
-	PublishedAt                    *time.Time      `json:"published_at,omitempty"`
+	PublishedAt                    *time.Time      `json:"published_at"`
 	PublishedScope                 string          `json:"published_scope,omitempty"`
 	Tags                           string          `json:"tags,omitempty"`
 	Options                        []ProductOption `json:"options,omitempty"`


### PR DESCRIPTION
If you want to unpublished some products from Shopify, you need to set published_at is null and send a post request to Shopify. But the struct: goshopify.Product 
`PublishedAt                    *time.Time      `json:"published_at,omitempty"` `

The omitempty will lead to the field "published_at"  lost in json object after executing json.Marshal function when you set published_at is null. So just remove it.