### PR TITLE
Add product pagination

### DIFF
--- a/goshopify.go
+++ b/goshopify.go
@@ -250,7 +250,7 @@ func NewClient(app App, shopName, token string, opts ...Option) *Client {
 // Do sends an API request and populates the given interface with the parsed
 // response. It does not make much sense to call Do without a prepared
 // interface instance.
-func (c *Client) Do(req *http.Request, v interface{}) error {
+func (c *Client) Do(req *http.Request, v interface{}, headers *http.Header) error {
 	resp, err := c.Client.Do(req)
 	if err != nil {
 		return err
@@ -270,6 +270,9 @@ func (c *Client) Do(req *http.Request, v interface{}) error {
 		}
 	}
 
+	if (headers != nil) {
+		*headers = resp.Header
+	}
 	return nil
 }
 
@@ -376,7 +379,6 @@ func CheckResponseError(r *http.Response) error {
 
 // General list options that can be used for most collections of entities.
 type ListOptions struct {
-	Page         int       `url:"page,omitempty"`
 	Limit        int       `url:"limit,omitempty"`
 	SinceID      int64     `url:"since_id,omitempty"`
 	CreatedAtMin time.Time `url:"created_at_min,omitempty"`
@@ -387,6 +389,7 @@ type ListOptions struct {
 	Fields       string    `url:"fields,omitempty"`
 	Vendor       string    `url:"vendor,omitempty"`
 	IDs          []int64   `url:"ids,omitempty,comma"`
+	PageInfo     string    `url:"page_info,omitempty"`
 }
 
 // General count options that can be used for most collection counts.
@@ -414,13 +417,13 @@ func (c *Client) Count(path string, options interface{}) (int, error) {
 // The options argument is used for specifying request options such as search
 // parameters like created_at_min
 // Any data returned from Shopify will be marshalled into resource argument.
-func (c *Client) CreateAndDo(method, path string, data, options, resource interface{}) error {
+func (c *Client) CreateAndDo(method, path string, data, options, resource interface{}, headers *http.Header) error {
 	req, err := c.NewRequest(method, path, data, options)
 	if err != nil {
 		return err
 	}
 
-	err = c.Do(req, resource)
+	err = c.Do(req, resource, headers)
 	if err != nil {
 		return err
 	}
@@ -431,22 +434,22 @@ func (c *Client) CreateAndDo(method, path string, data, options, resource interf
 // Get performs a GET request for the given path and saves the result in the
 // given resource.
 func (c *Client) Get(path string, resource, options interface{}) error {
-	return c.CreateAndDo("GET", path, nil, options, resource)
+	return c.CreateAndDo("GET", path, nil, options, resource, nil)
 }
 
 // Post performs a POST request for the given path and saves the result in the
 // given resource.
 func (c *Client) Post(path string, data, resource interface{}) error {
-	return c.CreateAndDo("POST", path, data, nil, resource)
+	return c.CreateAndDo("POST", path, data, nil, resource, nil)
 }
 
 // Put performs a PUT request for the given path and saves the result in the
 // given resource.
 func (c *Client) Put(path string, data, resource interface{}) error {
-	return c.CreateAndDo("PUT", path, data, nil, resource)
+	return c.CreateAndDo("PUT", path, data, nil, resource, nil)
 }
 
 // Delete performs a DELETE request for the given path
 func (c *Client) Delete(path string) error {
-	return c.CreateAndDo("DELETE", path, nil, nil, nil)
+	return c.CreateAndDo("DELETE", path, nil, nil, nil, nil)
 }

--- a/goshopify_test.go
+++ b/goshopify_test.go
@@ -338,7 +338,8 @@ func TestDo(t *testing.T) {
 
 		body := new(MyStruct)
 		req, _ := client.NewRequest("GET", c.url, nil, nil)
-		err := client.Do(req, body)
+		headers := new(http.Header)
+		err := client.Do(req, body, headers)
 
 		if err != nil {
 			if e, ok := err.(*url.Error); ok {
@@ -413,11 +414,12 @@ func TestCustomHTTPClientDo(t *testing.T) {
 		httpmock.RegisterResponder("GET", shopUrl, c.responder)
 
 		body := new(MyStruct)
+		headers := new(http.Header)
 		req, err := client.NewRequest("GET", c.url, nil, nil)
 		if err != nil {
 			t.Fatal(c.url, err)
 		}
-		err = client.Do(req, body)
+		err = client.Do(req, body, headers)
 		if err != nil {
 			t.Fatal(c.url, err)
 		}
@@ -471,7 +473,8 @@ func TestCreateAndDo(t *testing.T) {
 	for _, c := range cases {
 		httpmock.RegisterResponder("GET", c.url, c.responder)
 		body := new(MyStruct)
-		err := client.CreateAndDo("GET", c.url, nil, nil, body)
+		headers := new(http.Header)
+		err := client.CreateAndDo("GET", c.url, nil, nil, body, headers)
 
 		if err != nil && fmt.Sprint(err) != fmt.Sprint(c.expected) {
 			t.Errorf("CreateAndDo(): expected error %v, actual %v", c.expected, err)

--- a/oauth.go
+++ b/oauth.go
@@ -50,7 +50,7 @@ func (app App) GetAccessToken(shopName string, code string) (string, error) {
 	req, err := client.NewRequest("POST", "admin/oauth/access_token", data, nil)
 
 	token := new(Token)
-	err = client.Do(req, token)
+	err = client.Do(req, token, nil)
 	return token.Token, err
 }
 


### PR DESCRIPTION
Adds support for the new product pagination implementation which returns pagination information in the response header. Support for the current 'page' method will be ending on 04-2020.

Add new method `ListWithPagination()` was added to product, this keeps `List()` backwards compatible. 
As well as the list of products `ListWithPagination()` returns a `Pagination` instance, this contains `NextPageOptions` and `PreviousPageOptions` which can be passed into `ListWithPagination()` to get the next/previous set of results.

`headers` was not added to `Get()`, `Post()`, `Put()`, `Delete()` as these are the most common methods use so would create a reasonable backwards compatibility issue.

Here's an example of retrieving all products using the new pagination:
```
    type listRequest struct {
        goshopify.ListOptions
        PublishedStatus string `url:"published_status,omitempty"` 
    }

    options := interface{}(listRequest{
        ListOptions: goshopify.ListOptions{
            Limit: 250,
        },
        PublishedStatus: "published",
    })

    for true {
        prods, pagination, err := c.Product.ListWithPagination(options)
        if err != nil {
            return nil, errors.Wrapf(err, "could not list products")
        }

        products = append(products, prods...)
        if (pagination.NextPageOptions == nil) {
            break
        }

        options = interface{}(pagination.NextPageOptions)
    }
```