### PR TITLE
[wip] moving apiGlobalPrefix to the client

### DIFF
--- a/applicationcharge.go
+++ b/applicationcharge.go
@@ -52,28 +52,28 @@ type ApplicationChargesResource struct {
 
 // Create creates new application charge.
 func (a ApplicationChargeServiceOp) Create(charge ApplicationCharge) (*ApplicationCharge, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, applicationChargesBasePath)
+	path := fmt.Sprintf("%s.json", applicationChargesBasePath)
 	resource := &ApplicationChargeResource{}
 	return resource.Charge, a.client.Post(path, ApplicationChargeResource{Charge: &charge}, resource)
 }
 
 // Get gets individual application charge.
 func (a ApplicationChargeServiceOp) Get(chargeID int64, options interface{}) (*ApplicationCharge, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, applicationChargesBasePath, chargeID)
+	path := fmt.Sprintf("%s/%d.json", applicationChargesBasePath, chargeID)
 	resource := &ApplicationChargeResource{}
 	return resource.Charge, a.client.Get(path, resource, options)
 }
 
 // List gets all application charges.
 func (a ApplicationChargeServiceOp) List(options interface{}) ([]ApplicationCharge, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, applicationChargesBasePath)
+	path := fmt.Sprintf("%s.json", applicationChargesBasePath)
 	resource := &ApplicationChargesResource{}
 	return resource.Charges, a.client.Get(path, resource, options)
 }
 
 // Activate activates application charge.
 func (a ApplicationChargeServiceOp) Activate(charge ApplicationCharge) (*ApplicationCharge, error) {
-	path := fmt.Sprintf("%s/%s/%d/activate.json", globalApiPathPrefix, applicationChargesBasePath, charge.ID)
+	path := fmt.Sprintf("/%s/%d/activate.json", applicationChargesBasePath, charge.ID)
 	resource := &ApplicationChargeResource{}
 	return resource.Charge, a.client.Post(path, ApplicationChargeResource{Charge: &charge}, resource)
 }

--- a/applicationcharge_test.go
+++ b/applicationcharge_test.go
@@ -34,7 +34,7 @@ func applicationChargeTests(t *testing.T, charge ApplicationCharge) {
 		},
 		{
 			"ConfirmationURL",
-			fmt.Sprintf("https://apple.myshopify.com/%s/charges/1017262355/confirm_application_charge?signature=BAhpBBMxojw%%3D--1139a82a3433b1a6771786e03f02300440e11883", globalApiPathPrefix),
+			fmt.Sprintf("https://apple.myshopify.com/%s/charges/1017262355/confirm_application_charge?signature=BAhpBBMxojw%%3D--1139a82a3433b1a6771786e03f02300440e11883", defaultApiPathPrefix),
 			charge.ConfirmationURL,
 		},
 	}
@@ -52,7 +52,7 @@ func TestApplicationChargeServiceOp_Create(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"POST",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/application_charges.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/application_charges.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("applicationcharge.json")),
 	)
 
@@ -77,7 +77,7 @@ func TestApplicationChargeServiceOp_Get(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/application_charges/1.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/application_charges/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"application_charge": {"id":1}}`),
 	)
 
@@ -98,7 +98,7 @@ func TestApplicationChargeServiceOp_List(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/application_charges.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/application_charges.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"application_charges": [{"id":1},{"id":2}]}`),
 	)
 
@@ -119,7 +119,7 @@ func TestApplicationChargeServiceOp_Activate(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"POST",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/application_charges/455696195/activate.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/application_charges/455696195/activate.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(
 			200,
 			`{"application_charge":{"id":455696195,"status":"active"}}`,

--- a/asset.go
+++ b/asset.go
@@ -55,7 +55,7 @@ type assetGetOptions struct {
 
 // List the metadata for all assets in the given theme
 func (s *AssetServiceOp) List(themeID int64, options interface{}) ([]Asset, error) {
-	path := fmt.Sprintf("%s/%s/%d/assets.json", globalApiPathPrefix, assetsBasePath, themeID)
+	path := fmt.Sprintf("%s/%d/assets.json", assetsBasePath, themeID)
 	resource := new(AssetsResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Assets, err
@@ -63,7 +63,7 @@ func (s *AssetServiceOp) List(themeID int64, options interface{}) ([]Asset, erro
 
 // Get an asset by key from the given theme
 func (s *AssetServiceOp) Get(themeID int64, key string) (*Asset, error) {
-	path := fmt.Sprintf("%s/%s/%d/assets.json", globalApiPathPrefix, assetsBasePath, themeID)
+	path := fmt.Sprintf("%s/%d/assets.json", assetsBasePath, themeID)
 	options := assetGetOptions{
 		Key:     key,
 		ThemeID: themeID,
@@ -75,7 +75,7 @@ func (s *AssetServiceOp) Get(themeID int64, key string) (*Asset, error) {
 
 // Update an asset
 func (s *AssetServiceOp) Update(themeID int64, asset Asset) (*Asset, error) {
-	path := fmt.Sprintf("%s/%s/%d/assets.json", globalApiPathPrefix, assetsBasePath, themeID)
+	path := fmt.Sprintf("%s/%d/assets.json", assetsBasePath, themeID)
 	wrappedData := AssetResource{Asset: &asset}
 	resource := new(AssetResource)
 	err := s.client.Put(path, wrappedData, resource)
@@ -84,6 +84,6 @@ func (s *AssetServiceOp) Update(themeID int64, asset Asset) (*Asset, error) {
 
 // Delete an asset
 func (s *AssetServiceOp) Delete(themeID int64, key string) error {
-	path := fmt.Sprintf("%s/%s/%d/assets.json?asset[key]=%s", globalApiPathPrefix, assetsBasePath, themeID, key)
+	path := fmt.Sprintf("%s/%d/assets.json?asset[key]=%s", assetsBasePath, themeID, key)
 	return s.client.Delete(path)
 }

--- a/asset_test.go
+++ b/asset_test.go
@@ -21,7 +21,7 @@ func TestAssetList(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/themes/1/assets.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/themes/1/assets.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(
 			200,
 			`{"assets": [{"key":"assets\/1.liquid"},{"key":"assets\/2.liquid"}]}`,
@@ -48,7 +48,7 @@ func TestAssetGet(t *testing.T) {
 	}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/themes/1/assets.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/themes/1/assets.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(
 			200,
@@ -73,7 +73,7 @@ func TestAssetUpdate(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"PUT",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/themes/1/assets.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/themes/1/assets.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(
 			200,
 			loadFixture("asset.json"),
@@ -101,7 +101,7 @@ func TestAssetDelete(t *testing.T) {
 	params := map[string]string{"asset[key]": "foo/bar.liquid"}
 	httpmock.RegisterResponderWithQuery(
 		"DELETE",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/themes/1/assets.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/themes/1/assets.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, "{}"),
 	)

--- a/blog.go
+++ b/blog.go
@@ -52,7 +52,7 @@ type BlogResource struct {
 
 // List all blogs
 func (s *BlogServiceOp) List(options interface{}) ([]Blog, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, blogsBasePath)
+	path := fmt.Sprintf("%s.json", blogsBasePath)
 	resource := new(BlogsResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Blogs, err
@@ -60,13 +60,13 @@ func (s *BlogServiceOp) List(options interface{}) ([]Blog, error) {
 
 // Count blogs
 func (s *BlogServiceOp) Count(options interface{}) (int, error) {
-	path := fmt.Sprintf("%s/%s/count.json", globalApiPathPrefix, blogsBasePath)
+	path := fmt.Sprintf("%s/count.json", blogsBasePath)
 	return s.client.Count(path, options)
 }
 
 // Get single blog
 func (s *BlogServiceOp) Get(blogId int64, options interface{}) (*Blog, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, blogsBasePath, blogId)
+	path := fmt.Sprintf("%s/%d.json", blogsBasePath, blogId)
 	resource := new(BlogResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Blog, err
@@ -74,7 +74,7 @@ func (s *BlogServiceOp) Get(blogId int64, options interface{}) (*Blog, error) {
 
 // Create a new blog
 func (s *BlogServiceOp) Create(blog Blog) (*Blog, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, blogsBasePath)
+	path := fmt.Sprintf("%s.json", blogsBasePath)
 	wrappedData := BlogResource{Blog: &blog}
 	resource := new(BlogResource)
 	err := s.client.Post(path, wrappedData, resource)
@@ -83,7 +83,7 @@ func (s *BlogServiceOp) Create(blog Blog) (*Blog, error) {
 
 // Update an existing blog
 func (s *BlogServiceOp) Update(blog Blog) (*Blog, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, blogsBasePath, blog.ID)
+	path := fmt.Sprintf("%s/%d.json", blogsBasePath, blog.ID)
 	wrappedData := BlogResource{Blog: &blog}
 	resource := new(BlogResource)
 	err := s.client.Put(path, wrappedData, resource)
@@ -92,5 +92,5 @@ func (s *BlogServiceOp) Update(blog Blog) (*Blog, error) {
 
 // Delete an blog
 func (s *BlogServiceOp) Delete(blogId int64) error {
-	return s.client.Delete(fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, blogsBasePath, blogId))
+	return s.client.Delete(fmt.Sprintf("%s/%d.json", blogsBasePath, blogId))
 }

--- a/blog_test.go
+++ b/blog_test.go
@@ -14,7 +14,7 @@ func TestBlogList(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/blogs.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/blogs.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(
 			200,
 			`{"blogs": [{"id":1},{"id":2}]}`,
@@ -39,7 +39,7 @@ func TestBlogCount(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/blogs/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/blogs/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(
 			200,
 			`{"count": 5}`,
@@ -64,7 +64,7 @@ func TestBlogGet(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/blogs/1.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/blogs/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(
 			200,
 			`{"blog": {"id":1}}`,
@@ -89,7 +89,7 @@ func TestBlogCreate(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"POST",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/blogs.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/blogs.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(
 			200,
 			loadFixture("blog.json"),
@@ -118,7 +118,7 @@ func TestBlogUpdate(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"PUT",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/blogs/1.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/blogs/1.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(
 			200,
 			loadFixture("blog.json"),
@@ -145,7 +145,7 @@ func TestBlogDelete(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/blogs/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/blogs/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.Blog.Delete(1)

--- a/collect.go
+++ b/collect.go
@@ -45,7 +45,7 @@ type CollectsResource struct {
 
 // List collects
 func (s *CollectServiceOp) List(options interface{}) ([]Collect, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, collectsBasePath)
+	path := fmt.Sprintf("%s.json", collectsBasePath)
 	resource := new(CollectsResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Collects, err
@@ -53,6 +53,6 @@ func (s *CollectServiceOp) List(options interface{}) ([]Collect, error) {
 
 // Count collects
 func (s *CollectServiceOp) Count(options interface{}) (int, error) {
-	path := fmt.Sprintf("%s/%s/count.json", globalApiPathPrefix, collectsBasePath)
+	path := fmt.Sprintf("%s/count.json", collectsBasePath)
 	return s.client.Count(path, options)
 }

--- a/collect_test.go
+++ b/collect_test.go
@@ -34,7 +34,7 @@ func TestCollectList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/collects.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/collects.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"collects": [{"id":1},{"id":2}]}`))
 
 	collects, err := client.Collect.List(nil)
@@ -52,12 +52,12 @@ func TestCollectCount(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/collects/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/collects/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 5}`))
 
 	params := map[string]string{"since_id": "123"}
 	httpmock.RegisterResponderWithQuery("GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/collects/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/collects/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 

--- a/customcollection.go
+++ b/customcollection.go
@@ -57,7 +57,7 @@ type CustomCollectionsResource struct {
 
 // List custom collections
 func (s *CustomCollectionServiceOp) List(options interface{}) ([]CustomCollection, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, customCollectionsBasePath)
+	path := fmt.Sprintf("%s.json", customCollectionsBasePath)
 	resource := new(CustomCollectionsResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Collections, err
@@ -65,13 +65,13 @@ func (s *CustomCollectionServiceOp) List(options interface{}) ([]CustomCollectio
 
 // Count custom collections
 func (s *CustomCollectionServiceOp) Count(options interface{}) (int, error) {
-	path := fmt.Sprintf("%s/%s/count.json", globalApiPathPrefix, customCollectionsBasePath)
+	path := fmt.Sprintf("%s/count.json", customCollectionsBasePath)
 	return s.client.Count(path, options)
 }
 
 // Get individual custom collection
 func (s *CustomCollectionServiceOp) Get(collectionID int64, options interface{}) (*CustomCollection, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, customCollectionsBasePath, collectionID)
+	path := fmt.Sprintf("%s/%d.json", customCollectionsBasePath, collectionID)
 	resource := new(CustomCollectionResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Collection, err
@@ -80,7 +80,7 @@ func (s *CustomCollectionServiceOp) Get(collectionID int64, options interface{})
 // Create a new custom collection
 // See Image for the details of the Image creation for a collection.
 func (s *CustomCollectionServiceOp) Create(collection CustomCollection) (*CustomCollection, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, customCollectionsBasePath)
+	path := fmt.Sprintf("%s.json", customCollectionsBasePath)
 	wrappedData := CustomCollectionResource{Collection: &collection}
 	resource := new(CustomCollectionResource)
 	err := s.client.Post(path, wrappedData, resource)
@@ -89,7 +89,7 @@ func (s *CustomCollectionServiceOp) Create(collection CustomCollection) (*Custom
 
 // Update an existing custom collection
 func (s *CustomCollectionServiceOp) Update(collection CustomCollection) (*CustomCollection, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, customCollectionsBasePath, collection.ID)
+	path := fmt.Sprintf("%s/%d.json", customCollectionsBasePath, collection.ID)
 	wrappedData := CustomCollectionResource{Collection: &collection}
 	resource := new(CustomCollectionResource)
 	err := s.client.Put(path, wrappedData, resource)
@@ -98,7 +98,7 @@ func (s *CustomCollectionServiceOp) Update(collection CustomCollection) (*Custom
 
 // Delete an existing custom collection.
 func (s *CustomCollectionServiceOp) Delete(collectionID int64) error {
-	return s.client.Delete(fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, customCollectionsBasePath, collectionID))
+	return s.client.Delete(fmt.Sprintf("%s/%d.json", customCollectionsBasePath, collectionID))
 }
 
 // List metafields for a custom collection

--- a/customcollection_test.go
+++ b/customcollection_test.go
@@ -35,7 +35,7 @@ func TestCustomCollectionList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/custom_collections.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/custom_collections.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"custom_collections": [{"id":1},{"id":2}]}`))
 
 	products, err := client.CustomCollection.List(nil)
@@ -53,13 +53,13 @@ func TestCustomCollectionCount(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/custom_collections/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/custom_collections/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 5}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/custom_collections/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/custom_collections/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -89,7 +89,7 @@ func TestCustomCollectionGet(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/custom_collections/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/custom_collections/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"custom_collection": {"id":1}}`))
 
 	product, err := client.CustomCollection.Get(1, nil)
@@ -107,7 +107,7 @@ func TestCustomCollectionCreate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/custom_collections.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/custom_collections.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("customcollection.json")))
 
 	collection := CustomCollection{
@@ -126,7 +126,7 @@ func TestCustomCollectionUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/custom_collections/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/custom_collections/1.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("customcollection.json")))
 
 	collection := CustomCollection{
@@ -146,7 +146,7 @@ func TestCustomCollectionDelete(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/custom_collections/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/custom_collections/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.CustomCollection.Delete(1)
@@ -159,7 +159,7 @@ func TestCustomCollectionListMetafields(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"metafields": [{"id":1},{"id":2}]}`))
 
 	metafields, err := client.CustomCollection.ListMetafields(1, nil)
@@ -177,13 +177,13 @@ func TestCustomCollectionCountMetafields(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 3}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -213,7 +213,7 @@ func TestCustomCollectionGetMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"metafield": {"id":2}}`))
 
 	metafield, err := client.CustomCollection.GetMetafield(1, 2, nil)
@@ -231,7 +231,7 @@ func TestCustomCollectionCreateMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
 
 	metafield := Metafield{
@@ -253,7 +253,7 @@ func TestCustomCollectionUpdateMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
 
 	metafield := Metafield{
@@ -276,7 +276,7 @@ func TestCustomCollectionDeleteMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.CustomCollection.DeleteMetafield(1, 2)

--- a/customer.go
+++ b/customer.go
@@ -85,7 +85,7 @@ type CustomerSearchOptions struct {
 
 // List customers
 func (s *CustomerServiceOp) List(options interface{}) ([]Customer, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, customersBasePath)
+	path := fmt.Sprintf("%s.json", customersBasePath)
 	resource := new(CustomersResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Customers, err
@@ -93,13 +93,13 @@ func (s *CustomerServiceOp) List(options interface{}) ([]Customer, error) {
 
 // Count customers
 func (s *CustomerServiceOp) Count(options interface{}) (int, error) {
-	path := fmt.Sprintf("%s/%s/count.json", globalApiPathPrefix, customersBasePath)
+	path := fmt.Sprintf("%s/count.json", customersBasePath)
 	return s.client.Count(path, options)
 }
 
 // Get customer
 func (s *CustomerServiceOp) Get(customerID int64, options interface{}) (*Customer, error) {
-	path := fmt.Sprintf("%s/%s/%v.json", globalApiPathPrefix, customersBasePath, customerID)
+	path := fmt.Sprintf("%s/%v.json", customersBasePath, customerID)
 	resource := new(CustomerResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Customer, err
@@ -107,7 +107,7 @@ func (s *CustomerServiceOp) Get(customerID int64, options interface{}) (*Custome
 
 // Create a new customer
 func (s *CustomerServiceOp) Create(customer Customer) (*Customer, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, customersBasePath)
+	path := fmt.Sprintf("%s.json", customersBasePath)
 	wrappedData := CustomerResource{Customer: &customer}
 	resource := new(CustomerResource)
 	err := s.client.Post(path, wrappedData, resource)
@@ -116,7 +116,7 @@ func (s *CustomerServiceOp) Create(customer Customer) (*Customer, error) {
 
 // Update an existing customer
 func (s *CustomerServiceOp) Update(customer Customer) (*Customer, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, customersBasePath, customer.ID)
+	path := fmt.Sprintf("%s/%d.json", customersBasePath, customer.ID)
 	wrappedData := CustomerResource{Customer: &customer}
 	resource := new(CustomerResource)
 	err := s.client.Put(path, wrappedData, resource)
@@ -125,13 +125,13 @@ func (s *CustomerServiceOp) Update(customer Customer) (*Customer, error) {
 
 // Delete an existing customer
 func (s *CustomerServiceOp) Delete(customerID int64) error {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, customersBasePath, customerID)
+	path := fmt.Sprintf("%s/%d.json", customersBasePath, customerID)
 	return s.client.Delete(path)
 }
 
 // Search customers
 func (s *CustomerServiceOp) Search(options interface{}) ([]Customer, error) {
-	path := fmt.Sprintf("%s/%s/search.json", globalApiPathPrefix, customersBasePath)
+	path := fmt.Sprintf("%s/search.json", customersBasePath)
 	resource := new(CustomersResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Customers, err
@@ -139,7 +139,7 @@ func (s *CustomerServiceOp) Search(options interface{}) ([]Customer, error) {
 
 // ListOrders retrieves all orders from a customer
 func (s *CustomerServiceOp) ListOrders(customerID int64, options interface{}) ([]Order, error) {
-	path := fmt.Sprintf("%s/%s/%d/orders.json", globalApiPathPrefix, customersBasePath, customerID)
+	path := fmt.Sprintf("%s/%d/orders.json", customersBasePath, customerID)
 	resource := new(OrdersResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Orders, err
@@ -147,7 +147,7 @@ func (s *CustomerServiceOp) ListOrders(customerID int64, options interface{}) ([
 
 // ListTags retrieves all unique tags across all customers
 func (s *CustomerServiceOp) ListTags(options interface{}) ([]string, error) {
-	path := fmt.Sprintf("%s/%s/tags.json", globalApiPathPrefix, customersBasePath)
+	path := fmt.Sprintf("%s/tags.json", customersBasePath)
 	resource := new(CustomerTagsResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Tags, err

--- a/customer_address.go
+++ b/customer_address.go
@@ -54,7 +54,7 @@ type CustomerAddressesResource struct {
 
 // List addresses
 func (s *CustomerAddressServiceOp) List(customerID int64, options interface{}) ([]CustomerAddress, error) {
-	path := fmt.Sprintf("%s/%s/%d/addresses.json", globalApiPathPrefix, customersBasePath, customerID)
+	path := fmt.Sprintf("%s/%d/addresses.json", customersBasePath, customerID)
 	resource := new(CustomerAddressesResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Addresses, err
@@ -62,7 +62,7 @@ func (s *CustomerAddressServiceOp) List(customerID int64, options interface{}) (
 
 // Get address
 func (s *CustomerAddressServiceOp) Get(customerID, addressID int64, options interface{}) (*CustomerAddress, error) {
-	path := fmt.Sprintf("%s/%s/%d/addresses/%d.json", globalApiPathPrefix, customersBasePath, customerID, addressID)
+	path := fmt.Sprintf("%s/%d/addresses/%d.json", customersBasePath, customerID, addressID)
 	resource := new(CustomerAddressResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Address, err
@@ -70,7 +70,7 @@ func (s *CustomerAddressServiceOp) Get(customerID, addressID int64, options inte
 
 // Create a new address for given customer
 func (s *CustomerAddressServiceOp) Create(customerID int64, address CustomerAddress) (*CustomerAddress, error) {
-	path := fmt.Sprintf("%s/%s/%d/addresses.json", globalApiPathPrefix, customersBasePath, customerID)
+	path := fmt.Sprintf("%s/%d/addresses.json", customersBasePath, customerID)
 	wrappedData := CustomerAddressResource{Address: &address}
 	resource := new(CustomerAddressResource)
 	err := s.client.Post(path, wrappedData, resource)
@@ -79,7 +79,7 @@ func (s *CustomerAddressServiceOp) Create(customerID int64, address CustomerAddr
 
 // Create a new address for given customer
 func (s *CustomerAddressServiceOp) Update(customerID int64, address CustomerAddress) (*CustomerAddress, error) {
-	path := fmt.Sprintf("%s/%s/%d/addresses/%d.json", globalApiPathPrefix, customersBasePath, customerID, address.ID)
+	path := fmt.Sprintf("%s/%d/addresses/%d.json", customersBasePath, customerID, address.ID)
 	wrappedData := CustomerAddressResource{Address: &address}
 	resource := new(CustomerAddressResource)
 	err := s.client.Put(path, wrappedData, resource)
@@ -88,5 +88,5 @@ func (s *CustomerAddressServiceOp) Update(customerID int64, address CustomerAddr
 
 // Delete an existing address
 func (s *CustomerAddressServiceOp) Delete(customerID, addressID int64) error {
-	return s.client.Delete(fmt.Sprintf("%s/%s/%d/addresses/%d.json", globalApiPathPrefix, customersBasePath, customerID, addressID))
+	return s.client.Delete(fmt.Sprintf("%s/%d/addresses/%d.json", customersBasePath, customerID, addressID))
 }

--- a/customer_address_test.go
+++ b/customer_address_test.go
@@ -98,7 +98,7 @@ func TestList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/addresses.json", globalApiPathPrefix), httpmock.NewBytesResponder(200, loadFixture("customer_addresses.json")))
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/addresses.json", defaultApiPathPrefix), httpmock.NewBytesResponder(200, loadFixture("customer_addresses.json")))
 
 	addresses, err := client.CustomerAddress.List(1, nil)
 	if err != nil {
@@ -115,7 +115,7 @@ func TestGet(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/addresses/1.json", globalApiPathPrefix), httpmock.NewBytesResponder(200, loadFixture("customer_address.json")))
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/addresses/1.json", defaultApiPathPrefix), httpmock.NewBytesResponder(200, loadFixture("customer_address.json")))
 
 	address, err := client.CustomerAddress.Get(1, 1, nil)
 	if err != nil {
@@ -129,7 +129,7 @@ func TestCreate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/addresses.json", globalApiPathPrefix), httpmock.NewBytesResponder(200, loadFixture("customer_address.json")))
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/addresses.json", defaultApiPathPrefix), httpmock.NewBytesResponder(200, loadFixture("customer_address.json")))
 
 	address, err := client.CustomerAddress.Create(1, CustomerAddress{})
 	if err != nil {
@@ -143,7 +143,7 @@ func TestUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/addresses/1.json", globalApiPathPrefix), httpmock.NewBytesResponder(200, loadFixture("customer_address.json")))
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/addresses/1.json", defaultApiPathPrefix), httpmock.NewBytesResponder(200, loadFixture("customer_address.json")))
 
 	address, err := client.CustomerAddress.Update(1, CustomerAddress{ID: 1})
 	if err != nil {
@@ -157,7 +157,7 @@ func TestDelete(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/addresses/1.json", globalApiPathPrefix), httpmock.NewStringResponder(200, "{}"))
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/addresses/1.json", defaultApiPathPrefix), httpmock.NewStringResponder(200, "{}"))
 
 	err := client.CustomerAddress.Delete(1, 1)
 	if err != nil {

--- a/customer_test.go
+++ b/customer_test.go
@@ -14,7 +14,7 @@ func TestCustomerList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"customers": [{"id":1},{"id":2}]}`))
 
 	customers, err := client.Customer.List(nil)
@@ -32,13 +32,13 @@ func TestCustomerCount(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 5}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -68,7 +68,7 @@ func TestCustomerSearch(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/search.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/search.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"customers": [{"id":1},{"id":2}]}`))
 
 	customers, err := client.Customer.Search(nil)
@@ -86,7 +86,7 @@ func TestCustomerGet(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("customer.json")))
 
 	customer, err := client.Customer.Get(1, nil)
@@ -235,7 +235,7 @@ func TestCustomerUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("customer.json")))
 
 	customer := Customer{
@@ -258,7 +258,7 @@ func TestCustomerCreate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("customer.json")))
 
 	customer := Customer{
@@ -281,7 +281,7 @@ func TestCustomerDelete(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, ""))
 
 	err := client.Customer.Delete(1)
@@ -294,7 +294,7 @@ func TestCustomerListMetafields(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/metafields.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/metafields.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"metafields": [{"id":1},{"id":2}]}`))
 
 	metafields, err := client.Customer.ListMetafields(1, nil)
@@ -312,13 +312,13 @@ func TestCustomerCountMetafields(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/metafields/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/metafields/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 3}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/metafields/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/metafields/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -348,7 +348,7 @@ func TestCustomerGetMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"metafield": {"id":2}}`))
 
 	metafield, err := client.Customer.GetMetafield(1, 2, nil)
@@ -366,7 +366,7 @@ func TestCustomerCreateMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/metafields.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/metafields.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
 
 	metafield := Metafield{
@@ -388,7 +388,7 @@ func TestCustomerUpdateMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
 
 	metafield := Metafield{
@@ -411,7 +411,7 @@ func TestCustomerDeleteMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.Customer.DeleteMetafield(1, 2)
@@ -426,13 +426,13 @@ func TestCustomerListOrders(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/orders.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/orders.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{\"orders\":[]}"),
 	)
 	params := map[string]string{"status": "any"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/orders.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/orders.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewBytesResponder(200, loadFixture("orders.json")),
 	)
@@ -467,7 +467,7 @@ func TestCustomerListTags(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/tags.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/tags.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("customer_tags.json")),
 	)
 

--- a/discount_code.go
+++ b/discount_code.go
@@ -46,7 +46,7 @@ type DiscountCodeResource struct {
 
 // Create a discount code
 func (s *DiscountCodeServiceOp) Create(priceRuleID int64, dc PriceRuleDiscountCode) (*PriceRuleDiscountCode, error) {
-	path := fmt.Sprintf("%s/"+discountCodeBasePath+".json", globalApiPathPrefix, priceRuleID)
+	path := fmt.Sprintf(discountCodeBasePath+".json", priceRuleID)
 	wrappedData := DiscountCodeResource{PriceRuleDiscountCode: &dc}
 	resource := new(DiscountCodeResource)
 	err := s.client.Post(path, wrappedData, resource)
@@ -55,7 +55,7 @@ func (s *DiscountCodeServiceOp) Create(priceRuleID int64, dc PriceRuleDiscountCo
 
 // Update an existing discount code
 func (s *DiscountCodeServiceOp) Update(priceRuleID int64, dc PriceRuleDiscountCode) (*PriceRuleDiscountCode, error) {
-	path := fmt.Sprintf("%s/"+discountCodeBasePath+"/%d.json", globalApiPathPrefix, priceRuleID, dc.ID)
+	path := fmt.Sprintf(discountCodeBasePath+"/%d.json", priceRuleID, dc.ID)
 	wrappedData := DiscountCodeResource{PriceRuleDiscountCode: &dc}
 	resource := new(DiscountCodeResource)
 	err := s.client.Put(path, wrappedData, resource)
@@ -64,7 +64,7 @@ func (s *DiscountCodeServiceOp) Update(priceRuleID int64, dc PriceRuleDiscountCo
 
 // List of discount codes
 func (s *DiscountCodeServiceOp) List(priceRuleID int64) ([]PriceRuleDiscountCode, error) {
-	path := fmt.Sprintf("%s/"+discountCodeBasePath+".json", globalApiPathPrefix, priceRuleID)
+	path := fmt.Sprintf(discountCodeBasePath+".json", priceRuleID)
 	resource := new(DiscountCodesResource)
 	err := s.client.Get(path, resource, nil)
 	return resource.DiscountCodes, err
@@ -72,7 +72,7 @@ func (s *DiscountCodeServiceOp) List(priceRuleID int64) ([]PriceRuleDiscountCode
 
 // Get a single discount code
 func (s *DiscountCodeServiceOp) Get(priceRuleID int64, discountCodeID int64) (*PriceRuleDiscountCode, error) {
-	path := fmt.Sprintf("%s/"+discountCodeBasePath+"/%d.json", globalApiPathPrefix, priceRuleID, discountCodeID)
+	path := fmt.Sprintf(discountCodeBasePath+"/%d.json", priceRuleID, discountCodeID)
 	resource := new(DiscountCodeResource)
 	err := s.client.Get(path, resource, nil)
 	return resource.PriceRuleDiscountCode, err
@@ -80,5 +80,5 @@ func (s *DiscountCodeServiceOp) Get(priceRuleID int64, discountCodeID int64) (*P
 
 // Delete a discount code
 func (s *DiscountCodeServiceOp) Delete(priceRuleID int64, discountCodeID int64) error {
-	return s.client.Delete(fmt.Sprintf("%s/"+discountCodeBasePath+"/%d.json", globalApiPathPrefix, priceRuleID, discountCodeID))
+	return s.client.Delete(fmt.Sprintf(discountCodeBasePath+"/%d.json", priceRuleID, discountCodeID))
 }

--- a/discount_code_test.go
+++ b/discount_code_test.go
@@ -13,7 +13,7 @@ func TestDiscountCodeList(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/price_rules/507328175/discount_codes.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/price_rules/507328175/discount_codes.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(
 			200,
 			`{"discount_codes":[{"id":507328175,"price_rule_id":507328175,"code":"SUMMERSALE10OFF","usage_count":0,"created_at":"2018-07-05T12:41:00-04:00","updated_at":"2018-07-05T12:41:00-04:00"}]}`,
@@ -38,7 +38,7 @@ func TestDiscountCodeGet(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/price_rules/507328175/discount_codes/507328175.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/price_rules/507328175/discount_codes/507328175.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(
 			200,
 			`{"discount_code":{"id":507328175,"price_rule_id":507328175,"code":"SUMMERSALE10OFF","usage_count":0,"created_at":"2018-07-05T12:41:00-04:00","updated_at":"2018-07-05T12:41:00-04:00"}}`,
@@ -64,7 +64,7 @@ func TestDiscountCodeCreate(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"POST",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/price_rules/507328175/discount_codes.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/price_rules/507328175/discount_codes.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(
 			201,
 			loadFixture("discount_code.json"),
@@ -93,7 +93,7 @@ func TestDiscountCodeUpdate(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"PUT",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/price_rules/507328175/discount_codes/1054381139.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/price_rules/507328175/discount_codes/1054381139.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(
 			200,
 			loadFixture("discount_code.json"),
@@ -120,7 +120,7 @@ func TestDiscountCodeDelete(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/price_rules/507328175/discount_codes/507328175.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/price_rules/507328175/discount_codes/507328175.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(204, "{}"))
 
 	err := client.DiscountCode.Delete(507328175, 507328175)

--- a/draft_order.go
+++ b/draft_order.go
@@ -119,7 +119,7 @@ type DraftOrderCountOptions struct {
 
 // Create draft order
 func (s *DraftOrderServiceOp) Create(draftOrder DraftOrder) (*DraftOrder, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, draftOrdersBasePath)
+	path := fmt.Sprintf("%s.json", draftOrdersBasePath)
 	wrappedData := DraftOrderResource{DraftOrder: &draftOrder}
 	resource := new(DraftOrderResource)
 	err := s.client.Post(path, wrappedData, resource)
@@ -128,7 +128,7 @@ func (s *DraftOrderServiceOp) Create(draftOrder DraftOrder) (*DraftOrder, error)
 
 // List draft orders
 func (s *DraftOrderServiceOp) List(options interface{}) ([]DraftOrder, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, draftOrdersBasePath)
+	path := fmt.Sprintf("%s.json", draftOrdersBasePath)
 	resource := new(DraftOrdersResource)
 	err := s.client.Get(path, resource, options)
 	return resource.DraftOrders, err
@@ -136,19 +136,19 @@ func (s *DraftOrderServiceOp) List(options interface{}) ([]DraftOrder, error) {
 
 // Count draft orders
 func (s *DraftOrderServiceOp) Count(options interface{}) (int, error) {
-	path := fmt.Sprintf("%s/%s/count.json", globalApiPathPrefix, draftOrdersBasePath)
+	path := fmt.Sprintf("%s/count.json", draftOrdersBasePath)
 	return s.client.Count(path, options)
 }
 
 // Delete draft orders
 func (s *DraftOrderServiceOp) Delete(draftOrderID int64) error {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, draftOrdersBasePath, draftOrderID)
+	path := fmt.Sprintf("%s/%d.json", draftOrdersBasePath, draftOrderID)
 	return s.client.Delete(path)
 }
 
 // Invoice a draft order
 func (s *DraftOrderServiceOp) Invoice(draftOrderID int64, draftOrderInvoice DraftOrderInvoice) (*DraftOrderInvoice, error) {
-	path := fmt.Sprintf("%s/%s/%d/send_invoice.json", globalApiPathPrefix, draftOrdersBasePath, draftOrderID)
+	path := fmt.Sprintf("%s/%d/send_invoice.json", draftOrdersBasePath, draftOrderID)
 	wrappedData := DraftOrderInvoiceResource{DraftOrderInvoice: &draftOrderInvoice}
 	resource := new(DraftOrderInvoiceResource)
 	err := s.client.Post(path, wrappedData, resource)
@@ -157,7 +157,7 @@ func (s *DraftOrderServiceOp) Invoice(draftOrderID int64, draftOrderInvoice Draf
 
 // Get individual draft order
 func (s *DraftOrderServiceOp) Get(draftOrderID int64, options interface{}) (*DraftOrder, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, draftOrdersBasePath, draftOrderID)
+	path := fmt.Sprintf("%s/%d.json", draftOrdersBasePath, draftOrderID)
 	resource := new(DraftOrderResource)
 	err := s.client.Get(path, resource, options)
 	return resource.DraftOrder, err
@@ -165,7 +165,7 @@ func (s *DraftOrderServiceOp) Get(draftOrderID int64, options interface{}) (*Dra
 
 // Update draft order
 func (s *DraftOrderServiceOp) Update(draftOrder DraftOrder) (*DraftOrder, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, draftOrdersBasePath, draftOrder.ID)
+	path := fmt.Sprintf("%s/%d.json", draftOrdersBasePath, draftOrder.ID)
 	wrappedData := DraftOrderResource{DraftOrder: &draftOrder}
 	resource := new(DraftOrderResource)
 	err := s.client.Put(path, wrappedData, resource)
@@ -174,7 +174,7 @@ func (s *DraftOrderServiceOp) Update(draftOrder DraftOrder) (*DraftOrder, error)
 
 // Complete draft order
 func (s *DraftOrderServiceOp) Complete(draftOrderID int64, paymentPending bool) (*DraftOrder, error) {
-	path := fmt.Sprintf("%s/%s/%d/complete.json?payment_pending=%t", globalApiPathPrefix, draftOrdersBasePath, draftOrderID, paymentPending)
+	path := fmt.Sprintf("%s/%d/complete.json?payment_pending=%t", draftOrdersBasePath, draftOrderID, paymentPending)
 	resource := new(DraftOrderResource)
 	err := s.client.Put(path, nil, resource)
 	return resource.DraftOrder, err

--- a/draft_order_test.go
+++ b/draft_order_test.go
@@ -55,7 +55,7 @@ func TestDraftOrderGet(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/994118539.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/994118539.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("draft_order.json")))
 
 	draftOrder, err := client.DraftOrder.Get(994118539, nil)
@@ -69,7 +69,7 @@ func TestDraftOrderCreate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(201, `{"draft_order":{"id": 1}}`))
 
 	draftOrder := DraftOrder{
@@ -96,7 +96,7 @@ func TestDraftOrderUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"draft_order":{"id": 1}}`))
 
 	draftOrder := DraftOrder{
@@ -121,13 +121,13 @@ func TestDraftOrderCount(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 7}`))
 
 	params := map[string]string{"status": "open"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -156,7 +156,7 @@ func TestDraftOrderList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("draft_orders.json")))
 
 	draftOrders, err := client.DraftOrder.List(nil)
@@ -181,7 +181,7 @@ func TestDraftOrderListOptions(t *testing.T) {
 	}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewBytesResponder(200, loadFixture("draft_orders.json")))
 
@@ -210,7 +210,7 @@ func TestDraftOrderInvoice(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"POST",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/send_invoice.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/send_invoice.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(201, loadFixture("invoice.json")))
 	invoice := DraftOrderInvoice{
 		To:   "first@example.com",
@@ -237,7 +237,7 @@ func TestDraftOrderDelete(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"DELETE",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, nil))
 
 	err := client.DraftOrder.Delete(1)
@@ -251,7 +251,7 @@ func TestDraftOrderComplete(t *testing.T) {
 	params := map[string]string{"payment_pending": "false"}
 	httpmock.RegisterResponderWithQuery(
 		"PUT",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/complete.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/complete.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewBytesResponder(200, loadFixture("draft_order.json")))
 
@@ -268,7 +268,7 @@ func TestDraftOrderCompletePending(t *testing.T) {
 	params := map[string]string{"payment_pending": "true"}
 	httpmock.RegisterResponderWithQuery(
 		"PUT",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/complete.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/complete.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewBytesResponder(200, loadFixture("draft_order.json")))
 
@@ -283,7 +283,7 @@ func TestDraftOrderListMetafields(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/metafields.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/metafields.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"metafields": [{"id":1},{"id":2}]}`))
 
 	metafields, err := client.DraftOrder.ListMetafields(1, nil)
@@ -301,13 +301,13 @@ func TestDraftOrderCountMetafields(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/metafields/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/metafields/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 3}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/metafields/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/metafields/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -337,7 +337,7 @@ func TestDraftOrderGetMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"metafield": {"id":2}}`))
 
 	metafield, err := client.DraftOrder.GetMetafield(1, 2, nil)
@@ -355,7 +355,7 @@ func TestDraftOrderCreateMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/metafields.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/metafields.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
 
 	metafield := Metafield{
@@ -377,7 +377,7 @@ func TestDraftOrderUpdateMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
 
 	metafield := Metafield{
@@ -400,7 +400,7 @@ func TestDraftOrderDeleteMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/draft_orders/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.DraftOrder.DeleteMetafield(1, 2)

--- a/fulfillment_test.go
+++ b/fulfillment_test.go
@@ -21,7 +21,7 @@ func TestFulfillmentList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123/fulfillments.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123/fulfillments.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"fulfillments": [{"id":1},{"id":2}]}`))
 
 	fulfillmentService := &FulfillmentServiceOp{client: client, resource: ordersResourceName, resourceID: 123}
@@ -41,13 +41,13 @@ func TestFulfillmentCount(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123/fulfillments/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123/fulfillments/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 3}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123/fulfillments/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123/fulfillments/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -79,7 +79,7 @@ func TestFulfillmentGet(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123/fulfillments/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123/fulfillments/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"fulfillment": {"id":1}}`))
 
 	fulfillmentService := &FulfillmentServiceOp{client: client, resource: ordersResourceName, resourceID: 123}
@@ -99,7 +99,7 @@ func TestFulfillmentCreate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123/fulfillments.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123/fulfillments.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("fulfillment.json")))
 
 	fulfillmentService := &FulfillmentServiceOp{client: client, resource: ordersResourceName, resourceID: 123}
@@ -126,7 +126,7 @@ func TestFulfillmentUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123/fulfillments/1022782888.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123/fulfillments/1022782888.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("fulfillment.json")))
 
 	fulfillmentService := &FulfillmentServiceOp{client: client, resource: ordersResourceName, resourceID: 123}
@@ -148,7 +148,7 @@ func TestFulfillmentComplete(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123/fulfillments/1/complete.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123/fulfillments/1/complete.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("fulfillment.json")))
 
 	fulfillmentService := &FulfillmentServiceOp{client: client, resource: ordersResourceName, resourceID: 123}
@@ -165,7 +165,7 @@ func TestFulfillmentTransition(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123/fulfillments/1/open.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123/fulfillments/1/open.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("fulfillment.json")))
 
 	fulfillmentService := &FulfillmentServiceOp{client: client, resource: ordersResourceName, resourceID: 123}
@@ -182,7 +182,7 @@ func TestFulfillmentCancel(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123/fulfillments/1/cancel.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123/fulfillments/1/cancel.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("fulfillment.json")))
 
 	fulfillmentService := &FulfillmentServiceOp{client: client, resource: ordersResourceName, resourceID: 123}

--- a/goshopify_test.go
+++ b/goshopify_test.go
@@ -63,32 +63,32 @@ func loadFixture(filename string) []byte {
 func TestWithVersion(t *testing.T) {
 	_ = NewClient(app, "fooshop", "abcd", WithVersion(testApiVersion))
 	expected := fmt.Sprintf("admin/api/%s", testApiVersion)
-	if globalApiPathPrefix != expected {
-		t.Errorf("WithVersion globalApiPathPrefix = %s, expected %s", globalApiPathPrefix, expected)
+	if defaultApiPathPrefix != expected {
+		t.Errorf("WithVersion defaultApiPathPrefix = %s, expected %s", defaultApiPathPrefix, expected)
 	}
 }
 
 func TestWithVersionNoVersion(t *testing.T) {
 	_ = NewClient(app, "fooshop", "abcd", WithVersion(""))
 	expected := "admin"
-	if globalApiPathPrefix != expected {
-		t.Errorf("WithVersion globalApiPathPrefix = %s, expected %s", globalApiPathPrefix, expected)
+	if defaultApiPathPrefix != expected {
+		t.Errorf("WithVersion defaultApiPathPrefix = %s, expected %s", defaultApiPathPrefix, expected)
 	}
 }
 
 func TestWithoutVersionInInitiation(t *testing.T) {
 	_ = NewClient(app, "fooshop", "abcd")
 	expected := "admin"
-	if globalApiPathPrefix != expected {
-		t.Errorf("WithVersion globalApiPathPrefix = %s, expected %s", globalApiPathPrefix, expected)
+	if defaultApiPathPrefix != expected {
+		t.Errorf("WithVersion defaultApiPathPrefix = %s, expected %s", defaultApiPathPrefix, expected)
 	}
 }
 
 func TestWithVersionInvalidVersion(t *testing.T) {
 	_ = NewClient(app, "fooshop", "abcd", WithVersion("9999-99b"))
 	expected := "admin"
-	if globalApiPathPrefix != expected {
-		t.Errorf("WithVersion globalApiPathPrefix = %s, expected %s", globalApiPathPrefix, expected)
+	if defaultApiPathPrefix != expected {
+		t.Errorf("WithVersion defaultApiPathPrefix = %s, expected %s", defaultApiPathPrefix, expected)
 	}
 }
 

--- a/image.go
+++ b/image.go
@@ -50,7 +50,7 @@ type ImagesResource struct {
 
 // List images
 func (s *ImageServiceOp) List(productID int64, options interface{}) ([]Image, error) {
-	path := fmt.Sprintf("%s/%s/%d/images.json", globalApiPathPrefix, productsBasePath, productID)
+	path := fmt.Sprintf("%s/%d/images.json", productsBasePath, productID)
 	resource := new(ImagesResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Images, err
@@ -58,13 +58,13 @@ func (s *ImageServiceOp) List(productID int64, options interface{}) ([]Image, er
 
 // Count images
 func (s *ImageServiceOp) Count(productID int64, options interface{}) (int, error) {
-	path := fmt.Sprintf("%s/%s/%d/images/count.json", globalApiPathPrefix, productsBasePath, productID)
+	path := fmt.Sprintf("%s/%d/images/count.json", productsBasePath, productID)
 	return s.client.Count(path, options)
 }
 
 // Get individual image
 func (s *ImageServiceOp) Get(productID int64, imageID int64, options interface{}) (*Image, error) {
-	path := fmt.Sprintf("%s/%s/%d/images/%d.json", globalApiPathPrefix, productsBasePath, productID, imageID)
+	path := fmt.Sprintf("%s/%d/images/%d.json", productsBasePath, productID, imageID)
 	resource := new(ImageResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Image, err
@@ -84,7 +84,7 @@ func (s *ImageServiceOp) Get(productID int64, imageID int64, options interface{}
 //
 // Shopify will accept Image.Attachment without Image.Filename.
 func (s *ImageServiceOp) Create(productID int64, image Image) (*Image, error) {
-	path := fmt.Sprintf("%s/%s/%d/images.json", globalApiPathPrefix, productsBasePath, productID)
+	path := fmt.Sprintf("%s/%d/images.json", productsBasePath, productID)
 	wrappedData := ImageResource{Image: &image}
 	resource := new(ImageResource)
 	err := s.client.Post(path, wrappedData, resource)
@@ -93,7 +93,7 @@ func (s *ImageServiceOp) Create(productID int64, image Image) (*Image, error) {
 
 // Update an existing image
 func (s *ImageServiceOp) Update(productID int64, image Image) (*Image, error) {
-	path := fmt.Sprintf("%s/%s/%d/images/%d.json", globalApiPathPrefix, productsBasePath, productID, image.ID)
+	path := fmt.Sprintf("%s/%d/images/%d.json", productsBasePath, productID, image.ID)
 	wrappedData := ImageResource{Image: &image}
 	resource := new(ImageResource)
 	err := s.client.Put(path, wrappedData, resource)
@@ -102,5 +102,5 @@ func (s *ImageServiceOp) Update(productID int64, image Image) (*Image, error) {
 
 // Delete an existing image
 func (s *ImageServiceOp) Delete(productID int64, imageID int64) error {
-	return s.client.Delete(fmt.Sprintf("%s/%s/%d/images/%d.json", globalApiPathPrefix, productsBasePath, productID, imageID))
+	return s.client.Delete(fmt.Sprintf("%s/%d/images/%d.json", productsBasePath, productID, imageID))
 }

--- a/image_test.go
+++ b/image_test.go
@@ -74,7 +74,7 @@ func TestImageList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/images.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/images.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("images.json")))
 
 	images, err := client.Image.List(1, nil)
@@ -94,13 +94,13 @@ func TestImageCount(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/images/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/images/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/images/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/images/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 1}`))
 
@@ -130,7 +130,7 @@ func TestImageGet(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/images/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/images/1.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("image.json")))
 
 	image, err := client.Image.Get(1, 1, nil)
@@ -145,7 +145,7 @@ func TestImageCreate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/images.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/images.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("image.json")))
 
 	variantIds := make([]int64, 2)
@@ -168,7 +168,7 @@ func TestImageUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/images/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/images/1.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("image.json")))
 
 	// Take an existing image
@@ -193,7 +193,7 @@ func TestImageDelete(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/images/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/images/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.Image.Delete(1, 1)

--- a/inventory_item.go
+++ b/inventory_item.go
@@ -46,7 +46,7 @@ type InventoryItemsResource struct {
 
 // List inventory items
 func (s *InventoryItemServiceOp) List(options interface{}) ([]InventoryItem, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, inventoryItemsBasePath)
+	path := fmt.Sprintf("%s.json", inventoryItemsBasePath)
 	resource := new(InventoryItemsResource)
 	err := s.client.Get(path, resource, options)
 	return resource.InventoryItems, err
@@ -54,7 +54,7 @@ func (s *InventoryItemServiceOp) List(options interface{}) ([]InventoryItem, err
 
 // Get a inventory item
 func (s *InventoryItemServiceOp) Get(id int64, options interface{}) (*InventoryItem, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, inventoryItemsBasePath, id)
+	path := fmt.Sprintf("%s/%d.json", inventoryItemsBasePath, id)
 	resource := new(InventoryItemResource)
 	err := s.client.Get(path, resource, options)
 	return resource.InventoryItem, err
@@ -62,7 +62,7 @@ func (s *InventoryItemServiceOp) Get(id int64, options interface{}) (*InventoryI
 
 // Update a inventory item
 func (s *InventoryItemServiceOp) Update(item InventoryItem) (*InventoryItem, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, inventoryItemsBasePath, item.ID)
+	path := fmt.Sprintf("%s/%d.json", inventoryItemsBasePath, item.ID)
 	wrappedData := InventoryItemResource{InventoryItem: &item}
 	resource := new(InventoryItemResource)
 	err := s.client.Put(path, wrappedData, resource)

--- a/inventory_item_test.go
+++ b/inventory_item_test.go
@@ -46,7 +46,7 @@ func TestInventoryItemsList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/inventory_items.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/inventory_items.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("inventory_items.json")))
 
 	items, err := client.InventoryItem.List(nil)
@@ -66,7 +66,7 @@ func TestInventoryItemsListWithIDs(t *testing.T) {
 	}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/inventory_items.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/inventory_items.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewBytesResponder(200, loadFixture("inventory_items.json")),
 	)
@@ -87,7 +87,7 @@ func TestInventoryItemGet(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/inventory_items/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/inventory_items/1.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("inventory_item.json")))
 
 	item, err := client.InventoryItem.Get(1, nil)
@@ -101,7 +101,7 @@ func TestInventoryItemUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/inventory_items/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/inventory_items/1.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("inventory_item.json")))
 
 	item := InventoryItem{

--- a/location.go
+++ b/location.go
@@ -81,21 +81,21 @@ type LocationServiceOp struct {
 }
 
 func (s *LocationServiceOp) List(options interface{}) ([]Location, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, locationsBasePath)
+	path := fmt.Sprintf("%s.json", locationsBasePath)
 	resource := new(LocationsResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Locations, err
 }
 
 func (s *LocationServiceOp) Get(ID int64, options interface{}) (*Location, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, locationsBasePath, ID)
+	path := fmt.Sprintf("%s/%d.json", locationsBasePath, ID)
 	resource := new(LocationResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Location, err
 }
 
 func (s *LocationServiceOp) Count(options interface{}) (int, error) {
-	path := fmt.Sprintf("%s/%s/count.json", globalApiPathPrefix, locationsBasePath)
+	path := fmt.Sprintf("%s/count.json", locationsBasePath)
 	return s.client.Count(path, options)
 }
 

--- a/location_test.go
+++ b/location_test.go
@@ -13,7 +13,7 @@ func TestLocationServiceOp_List(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/locations.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/locations.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("locations.json")))
 
 	products, err := client.Location.List(nil)
@@ -51,7 +51,7 @@ func TestLocationServiceOp_Get(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/locations/4688969785.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/locations/4688969785.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("location.json")))
 
 	product, err := client.Location.Get(4688969785, nil)
@@ -89,7 +89,7 @@ func TestLocationServiceOp_Count(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/locations/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/locations/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 3}`))
 
 	cnt, err := client.Location.Count(nil)

--- a/metafield_test.go
+++ b/metafield_test.go
@@ -21,7 +21,7 @@ func TestMetafieldList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"metafields": [{"id":1},{"id":2}]}`))
 
 	metafields, err := client.Metafield.List(nil)
@@ -39,13 +39,13 @@ func TestMetafieldCount(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 3}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -75,7 +75,7 @@ func TestMetafieldGet(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"metafield": {"id":1}}`))
 
 	metafield, err := client.Metafield.Get(1, nil)
@@ -93,7 +93,7 @@ func TestMetafieldCreate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
 
 	metafield := Metafield{
@@ -115,7 +115,7 @@ func TestMetafieldUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields/1.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
 
 	metafield := Metafield{
@@ -136,7 +136,7 @@ func TestMetafieldDelete(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.Metafield.Delete(1)

--- a/order.go
+++ b/order.go
@@ -287,7 +287,7 @@ type RefundLineItem struct {
 
 // List orders
 func (s *OrderServiceOp) List(options interface{}) ([]Order, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, ordersBasePath)
+	path := fmt.Sprintf("%s.json", ordersBasePath)
 	resource := new(OrdersResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Orders, err
@@ -295,13 +295,13 @@ func (s *OrderServiceOp) List(options interface{}) ([]Order, error) {
 
 // Count orders
 func (s *OrderServiceOp) Count(options interface{}) (int, error) {
-	path := fmt.Sprintf("%s/%s/count.json", globalApiPathPrefix, ordersBasePath)
+	path := fmt.Sprintf("%s/count.json", ordersBasePath)
 	return s.client.Count(path, options)
 }
 
 // Get individual order
 func (s *OrderServiceOp) Get(orderID int64, options interface{}) (*Order, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, ordersBasePath, orderID)
+	path := fmt.Sprintf("%s/%d.json", ordersBasePath, orderID)
 	resource := new(OrderResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Order, err
@@ -309,7 +309,7 @@ func (s *OrderServiceOp) Get(orderID int64, options interface{}) (*Order, error)
 
 // Create order
 func (s *OrderServiceOp) Create(order Order) (*Order, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, ordersBasePath)
+	path := fmt.Sprintf("%s.json", ordersBasePath)
 	wrappedData := OrderResource{Order: &order}
 	resource := new(OrderResource)
 	err := s.client.Post(path, wrappedData, resource)
@@ -318,7 +318,7 @@ func (s *OrderServiceOp) Create(order Order) (*Order, error) {
 
 // Update order
 func (s *OrderServiceOp) Update(order Order) (*Order, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, ordersBasePath, order.ID)
+	path := fmt.Sprintf("%s/%d.json", ordersBasePath, order.ID)
 	wrappedData := OrderResource{Order: &order}
 	resource := new(OrderResource)
 	err := s.client.Put(path, wrappedData, resource)

--- a/order_test.go
+++ b/order_test.go
@@ -69,7 +69,7 @@ func TestOrderList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("orders.json")))
 
 	orders, err := client.Order.List(nil)
@@ -97,7 +97,7 @@ func TestOrderListOptions(t *testing.T) {
 	}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/orders.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/orders.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewBytesResponder(200, loadFixture("orders.json")))
 
@@ -125,7 +125,7 @@ func TestOrderGet(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123456.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123456.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("order.json")))
 
 	order, err := client.Order.Get(123456, nil)
@@ -148,7 +148,7 @@ func TestOrderGetWithTransactions(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123456.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/123456.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("order_with_transaction.json")))
 
 	options := struct {
@@ -177,13 +177,13 @@ func TestOrderCount(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 7}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -213,7 +213,7 @@ func TestOrderCreate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(201, `{"order":{"id": 1}}`))
 
 	order := Order{
@@ -240,7 +240,7 @@ func TestOrderUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(201, `{"order":{"id": 1}}`))
 
 	order := Order{
@@ -264,7 +264,7 @@ func TestOrderListMetafields(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/metafields.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/metafields.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"metafields": [{"id":1},{"id":2}]}`))
 
 	metafields, err := client.Order.ListMetafields(1, nil)
@@ -282,13 +282,13 @@ func TestOrderCountMetafields(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/metafields/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/metafields/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 3}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/metafields/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/metafields/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -318,7 +318,7 @@ func TestOrderGetMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"metafield": {"id":2}}`))
 
 	metafield, err := client.Order.GetMetafield(1, 2, nil)
@@ -336,7 +336,7 @@ func TestOrderCreateMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/metafields.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/metafields.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
 
 	metafield := Metafield{
@@ -358,7 +358,7 @@ func TestOrderUpdateMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
 
 	metafield := Metafield{
@@ -381,7 +381,7 @@ func TestOrderDeleteMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.Order.DeleteMetafield(1, 2)
@@ -394,7 +394,7 @@ func TestOrderListFulfillments(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/fulfillments.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/fulfillments.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"fulfillments": [{"id":1},{"id":2}]}`))
 
 	fulfillments, err := client.Order.ListFulfillments(1, nil)
@@ -412,13 +412,13 @@ func TestOrderCountFulfillments(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/fulfillments/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/fulfillments/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 3}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/fulfillments/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/fulfillments/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -448,7 +448,7 @@ func TestOrderGetFulfillment(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/fulfillments/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/fulfillments/2.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"fulfillment": {"id":2}}`))
 
 	fulfillment, err := client.Order.GetFulfillment(1, 2, nil)
@@ -466,7 +466,7 @@ func TestOrderCreateFulfillment(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/fulfillments.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/fulfillments.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("fulfillment.json")))
 
 	fulfillment := Fulfillment{
@@ -491,7 +491,7 @@ func TestOrderUpdateFulfillment(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/fulfillments/1022782888.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/fulfillments/1022782888.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("fulfillment.json")))
 
 	fulfillment := Fulfillment{
@@ -510,7 +510,7 @@ func TestOrderCompleteFulfillment(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/fulfillments/2/complete.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/fulfillments/2/complete.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("fulfillment.json")))
 
 	returnedFulfillment, err := client.Order.CompleteFulfillment(1, 2)
@@ -525,7 +525,7 @@ func TestOrderTransitionFulfillment(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/fulfillments/2/open.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/fulfillments/2/open.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("fulfillment.json")))
 
 	returnedFulfillment, err := client.Order.TransitionFulfillment(1, 2)
@@ -540,7 +540,7 @@ func TestOrderCancelFulfillment(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/fulfillments/2/cancel.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/fulfillments/2/cancel.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("fulfillment.json")))
 
 	returnedFulfillment, err := client.Order.CancelFulfillment(1, 2)

--- a/page.go
+++ b/page.go
@@ -57,7 +57,7 @@ type PagesResource struct {
 
 // List pages
 func (s *PageServiceOp) List(options interface{}) ([]Page, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, pagesBasePath)
+	path := fmt.Sprintf("%s.json", pagesBasePath)
 	resource := new(PagesResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Pages, err
@@ -65,13 +65,13 @@ func (s *PageServiceOp) List(options interface{}) ([]Page, error) {
 
 // Count pages
 func (s *PageServiceOp) Count(options interface{}) (int, error) {
-	path := fmt.Sprintf("%s/%s/count.json", globalApiPathPrefix, pagesBasePath)
+	path := fmt.Sprintf("%s/count.json", pagesBasePath)
 	return s.client.Count(path, options)
 }
 
 // Get individual page
 func (s *PageServiceOp) Get(pageID int64, options interface{}) (*Page, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, pagesBasePath, pageID)
+	path := fmt.Sprintf("%s/%d.json", pagesBasePath, pageID)
 	resource := new(PageResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Page, err
@@ -79,7 +79,7 @@ func (s *PageServiceOp) Get(pageID int64, options interface{}) (*Page, error) {
 
 // Create a new page
 func (s *PageServiceOp) Create(page Page) (*Page, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, pagesBasePath)
+	path := fmt.Sprintf("%s.json", pagesBasePath)
 	wrappedData := PageResource{Page: &page}
 	resource := new(PageResource)
 	err := s.client.Post(path, wrappedData, resource)
@@ -88,7 +88,7 @@ func (s *PageServiceOp) Create(page Page) (*Page, error) {
 
 // Update an existing page
 func (s *PageServiceOp) Update(page Page) (*Page, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, pagesBasePath, page.ID)
+	path := fmt.Sprintf("%s/%d.json", pagesBasePath, page.ID)
 	wrappedData := PageResource{Page: &page}
 	resource := new(PageResource)
 	err := s.client.Put(path, wrappedData, resource)
@@ -97,7 +97,7 @@ func (s *PageServiceOp) Update(page Page) (*Page, error) {
 
 // Delete an existing page.
 func (s *PageServiceOp) Delete(pageID int64) error {
-	return s.client.Delete(fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, pagesBasePath, pageID))
+	return s.client.Delete(fmt.Sprintf("%s/%d.json", pagesBasePath, pageID))
 }
 
 // List metafields for a page

--- a/page_test.go
+++ b/page_test.go
@@ -21,7 +21,7 @@ func TestPageList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"pages": [{"id":1},{"id":2}]}`))
 
 	pages, err := client.Page.List(nil)
@@ -39,13 +39,13 @@ func TestPageCount(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 3}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -75,7 +75,7 @@ func TestPageGet(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"page": {"id":1}}`))
 
 	page, err := client.Page.Get(1, nil)
@@ -93,7 +93,7 @@ func TestPageCreate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("page.json")))
 
 	page := Page{
@@ -113,7 +113,7 @@ func TestPageUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("page.json")))
 
 	page := Page{
@@ -132,7 +132,7 @@ func TestPageDelete(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.Page.Delete(1)
@@ -145,7 +145,7 @@ func TestPageListMetafields(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1/metafields.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1/metafields.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"metafields": [{"id":1},{"id":2}]}`))
 
 	metafields, err := client.Page.ListMetafields(1, nil)
@@ -163,13 +163,13 @@ func TestPageCountMetafields(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1/metafields/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1/metafields/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 3}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1/metafields/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1/metafields/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -199,7 +199,7 @@ func TestPageGetMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"metafield": {"id":2}}`))
 
 	metafield, err := client.Page.GetMetafield(1, 2, nil)
@@ -217,7 +217,7 @@ func TestPageCreateMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1/metafields.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1/metafields.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
 
 	metafield := Metafield{
@@ -239,7 +239,7 @@ func TestPageUpdateMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
 
 	metafield := Metafield{
@@ -262,7 +262,7 @@ func TestPageDeleteMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.Page.DeleteMetafield(1, 2)

--- a/product.go
+++ b/product.go
@@ -74,7 +74,7 @@ type ProductsResource struct {
 
 // List products
 func (s *ProductServiceOp) List(options interface{}) ([]Product, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, productsBasePath)
+	path := fmt.Sprintf("%s.json", productsBasePath)
 	resource := new(ProductsResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Products, err
@@ -82,13 +82,13 @@ func (s *ProductServiceOp) List(options interface{}) ([]Product, error) {
 
 // Count products
 func (s *ProductServiceOp) Count(options interface{}) (int, error) {
-	path := fmt.Sprintf("%s/%s/count.json", globalApiPathPrefix, productsBasePath)
+	path := fmt.Sprintf("%s/count.json", productsBasePath)
 	return s.client.Count(path, options)
 }
 
 // Get individual product
 func (s *ProductServiceOp) Get(productID int64, options interface{}) (*Product, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, productsBasePath, productID)
+	path := fmt.Sprintf("%s/%d.json", productsBasePath, productID)
 	resource := new(ProductResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Product, err
@@ -96,7 +96,7 @@ func (s *ProductServiceOp) Get(productID int64, options interface{}) (*Product, 
 
 // Create a new product
 func (s *ProductServiceOp) Create(product Product) (*Product, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, productsBasePath)
+	path := fmt.Sprintf("%s.json", productsBasePath)
 	wrappedData := ProductResource{Product: &product}
 	resource := new(ProductResource)
 	err := s.client.Post(path, wrappedData, resource)
@@ -105,7 +105,7 @@ func (s *ProductServiceOp) Create(product Product) (*Product, error) {
 
 // Update an existing product
 func (s *ProductServiceOp) Update(product Product) (*Product, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, productsBasePath, product.ID)
+	path := fmt.Sprintf("%s/%d.json", productsBasePath, product.ID)
 	wrappedData := ProductResource{Product: &product}
 	resource := new(ProductResource)
 	err := s.client.Put(path, wrappedData, resource)
@@ -114,7 +114,7 @@ func (s *ProductServiceOp) Update(product Product) (*Product, error) {
 
 // Delete an existing product
 func (s *ProductServiceOp) Delete(productID int64) error {
-	return s.client.Delete(fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, productsBasePath, productID))
+	return s.client.Delete(fmt.Sprintf("%s/%d.json", productsBasePath, productID))
 }
 
 // ListMetafields for a product

--- a/product_test.go
+++ b/product_test.go
@@ -21,7 +21,7 @@ func TestProductList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"products": [{"id":1},{"id":2}]}`))
 
 	products, err := client.Product.List(nil)
@@ -42,7 +42,7 @@ func TestProductListFilterByIds(t *testing.T) {
 	params := map[string]string{"ids": "1,2,3"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/products.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/products.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"products": [{"id":1},{"id":2},{"id":3}]}`))
 
@@ -63,13 +63,13 @@ func TestProductCount(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 3}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/products/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/products/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -99,7 +99,7 @@ func TestProductGet(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"product": {"id":1}}`))
 
 	product, err := client.Product.Get(1, nil)
@@ -117,7 +117,7 @@ func TestProductCreate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/products.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/products.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("product.json")))
 
 	product := Product{
@@ -139,7 +139,7 @@ func TestProductUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("product.json")))
 
 	product := Product{
@@ -159,7 +159,7 @@ func TestProductDelete(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.Product.Delete(1)
@@ -172,7 +172,7 @@ func TestProductListMetafields(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/metafields.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/metafields.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"metafields": [{"id":1},{"id":2}]}`))
 
 	metafields, err := client.Product.ListMetafields(1, nil)
@@ -190,13 +190,13 @@ func TestProductCountMetafields(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/metafields/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/metafields/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 3}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/metafields/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/metafields/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -226,7 +226,7 @@ func TestProductGetMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"metafield": {"id":2}}`))
 
 	metafield, err := client.Product.GetMetafield(1, 2, nil)
@@ -244,7 +244,7 @@ func TestProductCreateMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/metafields.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/metafields.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
 
 	metafield := Metafield{
@@ -266,7 +266,7 @@ func TestProductUpdateMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
 
 	metafield := Metafield{
@@ -289,7 +289,7 @@ func TestProductDeleteMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.Product.DeleteMetafield(1, 2)

--- a/recurringapplicationcharge.go
+++ b/recurringapplicationcharge.go
@@ -128,7 +128,7 @@ type RecurringApplicationChargesResource struct {
 func (r *RecurringApplicationChargeServiceOp) Create(charge RecurringApplicationCharge) (
 	*RecurringApplicationCharge, error) {
 
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, recurringApplicationChargesBasePath)
+	path := fmt.Sprintf("%s.json", recurringApplicationChargesBasePath)
 	wrappedData := RecurringApplicationChargeResource{Charge: &charge}
 	resource := &RecurringApplicationChargeResource{}
 	err := r.client.Post(path, wrappedData, resource)
@@ -139,7 +139,7 @@ func (r *RecurringApplicationChargeServiceOp) Create(charge RecurringApplication
 func (r *RecurringApplicationChargeServiceOp) Get(chargeID int64, options interface{}) (
 	*RecurringApplicationCharge, error) {
 
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, recurringApplicationChargesBasePath, chargeID)
+	path := fmt.Sprintf("%s/%d.json", recurringApplicationChargesBasePath, chargeID)
 	resource := &RecurringApplicationChargeResource{}
 	err := r.client.Get(path, resource, options)
 	return resource.Charge, err
@@ -149,7 +149,7 @@ func (r *RecurringApplicationChargeServiceOp) Get(chargeID int64, options interf
 func (r *RecurringApplicationChargeServiceOp) List(options interface{}) (
 	[]RecurringApplicationCharge, error) {
 
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, recurringApplicationChargesBasePath)
+	path := fmt.Sprintf("%s.json", recurringApplicationChargesBasePath)
 	resource := &RecurringApplicationChargesResource{}
 	err := r.client.Get(path, resource, options)
 	return resource.Charges, err
@@ -159,7 +159,7 @@ func (r *RecurringApplicationChargeServiceOp) List(options interface{}) (
 func (r *RecurringApplicationChargeServiceOp) Activate(charge RecurringApplicationCharge) (
 	*RecurringApplicationCharge, error) {
 
-	path := fmt.Sprintf("%s/%s/%d/activate.json", globalApiPathPrefix, recurringApplicationChargesBasePath, charge.ID)
+	path := fmt.Sprintf("%s/%d/activate.json", recurringApplicationChargesBasePath, charge.ID)
 	wrappedData := RecurringApplicationChargeResource{Charge: &charge}
 	resource := &RecurringApplicationChargeResource{}
 	err := r.client.Post(path, wrappedData, resource)
@@ -168,14 +168,14 @@ func (r *RecurringApplicationChargeServiceOp) Activate(charge RecurringApplicati
 
 // Delete deletes recurring application charge.
 func (r *RecurringApplicationChargeServiceOp) Delete(chargeID int64) error {
-	return r.client.Delete(fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, recurringApplicationChargesBasePath, chargeID))
+	return r.client.Delete(fmt.Sprintf("%s/%d.json", recurringApplicationChargesBasePath, chargeID))
 }
 
 // Update updates recurring application charge.
 func (r *RecurringApplicationChargeServiceOp) Update(chargeID, newCappedAmount int64) (
 	*RecurringApplicationCharge, error) {
 
-	path := fmt.Sprintf("%s/%s/%d/customize.json?recurring_application_charge[capped_amount]=%d", globalApiPathPrefix,
+	path := fmt.Sprintf("%s/%d/customize.json?recurring_application_charge[capped_amount]=%d",
 		recurringApplicationChargesBasePath, chargeID, newCappedAmount)
 	resource := &RecurringApplicationChargeResource{}
 	err := r.client.Put(path, nil, resource)

--- a/recurringapplicationcharge_test.go
+++ b/recurringapplicationcharge_test.go
@@ -43,7 +43,7 @@ func recurringApplicationChargeTests(t *testing.T, charge RecurringApplicationCh
 		{
 			"ConfirmationURL",
 			fmt.Sprintf("https://apple.myshopify.com/%s/charges/1029266948/confirm_recurring_application_c"+
-				"harge?signature=BAhpBAReWT0%%3D--b51a6db06a3792c4439783fcf0f2e89bf1c9df68", globalApiPathPrefix),
+				"harge?signature=BAhpBAReWT0%%3D--b51a6db06a3792c4439783fcf0f2e89bf1c9df68", defaultApiPathPrefix),
 			charge.ConfirmationURL,
 		},
 	}
@@ -91,7 +91,7 @@ func recurringApplicationChargeTestsAllFieldsAffected(t *testing.T,
 		{
 			"ConfirmationURL",
 			fmt.Sprintf("https://apple.myshopify.com/%s/charges/1029266948/confirm_recurring_application_c"+
-				"harge?signature=BAhpBAReWT0%%3D--b51a6db06a3792c4439783fcf0f2e89bf1c9df68", globalApiPathPrefix),
+				"harge?signature=BAhpBAReWT0%%3D--b51a6db06a3792c4439783fcf0f2e89bf1c9df68", defaultApiPathPrefix),
 			charge.ConfirmationURL,
 		},
 	}
@@ -110,7 +110,7 @@ func TestRecurringApplicationChargeServiceOp_Create(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"POST",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(
 			200, loadFixture("reccuringapplicationcharge/reccuringapplicationcharge.json"),
 		),
@@ -137,7 +137,7 @@ func TestRecurringApplicationChargeServiceOp_Get(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/1.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"recurring_application_charge": {"id":1}}`),
 	)
 
@@ -158,7 +158,7 @@ func TestRecurringApplicationChargeServiceOp_GetAllFieldsAffected(t *testing.T) 
 
 	httpmock.RegisterResponder(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/1029266948.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/1029266948.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(
 			200, loadFixture(
 				"reccuringapplicationcharge/reccuringapplicationcharge_all_fields_affected.json",
@@ -189,7 +189,7 @@ func TestRecurringApplicationChargeServiceOp_GetAllFieldsBad(t *testing.T) {
 
 		httpmock.RegisterResponder(
 			"GET",
-			fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/1029266948.json", globalApiPathPrefix),
+			fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/1029266948.json", defaultApiPathPrefix),
 			httpmock.NewBytesResponder(
 				200,
 				loadFixture(
@@ -212,7 +212,7 @@ func TestRecurringApplicationChargeServiceOp_List(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"recurring_application_charges": [{"id":1},{"id":2}]}`),
 	)
 
@@ -233,7 +233,7 @@ func TestRecurringApplicationChargeServiceOp_Activate(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"POST",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/455696195/activate.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/455696195/activate.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(
 			200, `{"recurring_application_charge":{"id":455696195,"status":"active"}}`,
 		),
@@ -261,7 +261,7 @@ func TestRecurringApplicationChargeServiceOp_Delete(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"DELETE",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/1.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"),
 	)
 
@@ -276,7 +276,7 @@ func TestRecurringApplicationChargeServiceOp_Update(t *testing.T) {
 	params := map[string]string{"recurring_application_charge[capped_amount]": "100"}
 	httpmock.RegisterResponderWithQuery(
 		"PUT",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/455696195/customize.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/455696195/customize.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(
 			200, `{"recurring_application_charge":{"id":455696195,"capped_amount":"100.00"}}`,

--- a/redirect.go
+++ b/redirect.go
@@ -43,7 +43,7 @@ type RedirectsResource struct {
 
 // List redirects
 func (s *RedirectServiceOp) List(options interface{}) ([]Redirect, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, redirectsBasePath)
+	path := fmt.Sprintf("%s.json", redirectsBasePath)
 	resource := new(RedirectsResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Redirects, err
@@ -51,13 +51,13 @@ func (s *RedirectServiceOp) List(options interface{}) ([]Redirect, error) {
 
 // Count redirects
 func (s *RedirectServiceOp) Count(options interface{}) (int, error) {
-	path := fmt.Sprintf("%s/%s/count.json", globalApiPathPrefix, redirectsBasePath)
+	path := fmt.Sprintf("%s/count.json", redirectsBasePath)
 	return s.client.Count(path, options)
 }
 
 // Get individual redirect
 func (s *RedirectServiceOp) Get(redirectID int64, options interface{}) (*Redirect, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, redirectsBasePath, redirectID)
+	path := fmt.Sprintf("%s/%d.json", redirectsBasePath, redirectID)
 	resource := new(RedirectResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Redirect, err
@@ -65,7 +65,7 @@ func (s *RedirectServiceOp) Get(redirectID int64, options interface{}) (*Redirec
 
 // Create a new redirect
 func (s *RedirectServiceOp) Create(redirect Redirect) (*Redirect, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, redirectsBasePath)
+	path := fmt.Sprintf("%s.json", redirectsBasePath)
 	wrappedData := RedirectResource{Redirect: &redirect}
 	resource := new(RedirectResource)
 	err := s.client.Post(path, wrappedData, resource)
@@ -74,7 +74,7 @@ func (s *RedirectServiceOp) Create(redirect Redirect) (*Redirect, error) {
 
 // Update an existing redirect
 func (s *RedirectServiceOp) Update(redirect Redirect) (*Redirect, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, redirectsBasePath, redirect.ID)
+	path := fmt.Sprintf("%s/%d.json", redirectsBasePath, redirect.ID)
 	wrappedData := RedirectResource{Redirect: &redirect}
 	resource := new(RedirectResource)
 	err := s.client.Put(path, wrappedData, resource)
@@ -83,5 +83,5 @@ func (s *RedirectServiceOp) Update(redirect Redirect) (*Redirect, error) {
 
 // Delete an existing redirect.
 func (s *RedirectServiceOp) Delete(redirectID int64) error {
-	return s.client.Delete(fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, redirectsBasePath, redirectID))
+	return s.client.Delete(fmt.Sprintf("%s/%d.json", redirectsBasePath, redirectID))
 }

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -21,7 +21,7 @@ func TestRedirectList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/redirects.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/redirects.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"redirects": [{"id":1},{"id":2}]}`))
 
 	redirects, err := client.Redirect.List(nil)
@@ -39,13 +39,13 @@ func TestRedirectCount(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/redirects/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/redirects/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 3}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/redirects/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/redirects/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -75,7 +75,7 @@ func TestRedirectGet(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/redirects/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/redirects/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"redirect": {"id":1}}`))
 
 	redirect, err := client.Redirect.Get(1, nil)
@@ -93,7 +93,7 @@ func TestRedirectCreate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/redirects.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/redirects.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("redirect.json")))
 
 	redirect := Redirect{
@@ -113,7 +113,7 @@ func TestRedirectUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/redirects/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/redirects/1.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("redirect.json")))
 
 	redirect := Redirect{
@@ -132,7 +132,7 @@ func TestRedirectDelete(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/redirects/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/redirects/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.Redirect.Delete(1)

--- a/scripttag.go
+++ b/scripttag.go
@@ -62,7 +62,7 @@ type ScriptTagResource struct {
 
 // List script tags
 func (s *ScriptTagServiceOp) List(options interface{}) ([]ScriptTag, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, scriptTagsBasePath)
+	path := fmt.Sprintf("%s.json", scriptTagsBasePath)
 	resource := &ScriptTagsResource{}
 	err := s.client.Get(path, resource, options)
 	return resource.ScriptTags, err
@@ -70,13 +70,13 @@ func (s *ScriptTagServiceOp) List(options interface{}) ([]ScriptTag, error) {
 
 // Count script tags
 func (s *ScriptTagServiceOp) Count(options interface{}) (int, error) {
-	path := fmt.Sprintf("%s/%s/count.json", globalApiPathPrefix, scriptTagsBasePath)
+	path := fmt.Sprintf("%s/count.json", scriptTagsBasePath)
 	return s.client.Count(path, options)
 }
 
 // Get individual script tag
 func (s *ScriptTagServiceOp) Get(tagID int64, options interface{}) (*ScriptTag, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, scriptTagsBasePath, tagID)
+	path := fmt.Sprintf("%s/%d.json", scriptTagsBasePath, tagID)
 	resource := &ScriptTagResource{}
 	err := s.client.Get(path, resource, options)
 	return resource.ScriptTag, err
@@ -84,7 +84,7 @@ func (s *ScriptTagServiceOp) Get(tagID int64, options interface{}) (*ScriptTag, 
 
 // Create a new script tag
 func (s *ScriptTagServiceOp) Create(tag ScriptTag) (*ScriptTag, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, scriptTagsBasePath)
+	path := fmt.Sprintf("%s.json", scriptTagsBasePath)
 	wrappedData := ScriptTagResource{ScriptTag: &tag}
 	resource := &ScriptTagResource{}
 	err := s.client.Post(path, wrappedData, resource)
@@ -93,7 +93,7 @@ func (s *ScriptTagServiceOp) Create(tag ScriptTag) (*ScriptTag, error) {
 
 // Update an existing script tag
 func (s *ScriptTagServiceOp) Update(tag ScriptTag) (*ScriptTag, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, scriptTagsBasePath, tag.ID)
+	path := fmt.Sprintf("%s/%d.json", scriptTagsBasePath, tag.ID)
 	wrappedData := ScriptTagResource{ScriptTag: &tag}
 	resource := &ScriptTagResource{}
 	err := s.client.Put(path, wrappedData, resource)
@@ -102,5 +102,5 @@ func (s *ScriptTagServiceOp) Update(tag ScriptTag) (*ScriptTag, error) {
 
 // Delete an existing script tag
 func (s *ScriptTagServiceOp) Delete(tagID int64) error {
-	return s.client.Delete(fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, scriptTagsBasePath, tagID))
+	return s.client.Delete(fmt.Sprintf("%s/%d.json", scriptTagsBasePath, tagID))
 }

--- a/scripttag_test.go
+++ b/scripttag_test.go
@@ -12,7 +12,7 @@ func TestScriptTagList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/script_tags.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/script_tags.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"script_tags": [{"id": 1},{"id": 2}]}`))
 
 	scriptTags, err := client.ScriptTag.List(nil)
@@ -30,7 +30,7 @@ func TestScriptTagCount(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/script_tags/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/script_tags/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 3}`))
 
 	cnt, err := client.ScriptTag.Count(nil)
@@ -48,7 +48,7 @@ func TestScriptTagGet(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/script_tags/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/script_tags/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"script_tag": {"id": 1}}`))
 
 	scriptTag, err := client.ScriptTag.Get(1, nil)
@@ -73,7 +73,7 @@ func TestScriptTagCreate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/script_tags.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/script_tags.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("script_tags.json")))
 
 	tag0 := ScriptTag{
@@ -93,7 +93,7 @@ func TestScriptTagUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/script_tags/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/script_tags/1.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("script_tags.json")))
 
 	tag := ScriptTag{
@@ -112,7 +112,7 @@ func TestScriptTagDelete(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/script_tags/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/script_tags/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	if err := client.ScriptTag.Delete(1); err != nil {

--- a/shop.go
+++ b/shop.go
@@ -1,7 +1,6 @@
 package goshopify
 
 import (
-	"fmt"
 	"time"
 )
 
@@ -79,6 +78,6 @@ type ShopResource struct {
 // Get shop
 func (s *ShopServiceOp) Get(options interface{}) (*Shop, error) {
 	resource := new(ShopResource)
-	err := s.client.Get(fmt.Sprintf("%s/shop.json", globalApiPathPrefix), resource, options)
+	err := s.client.Get("shop.json", resource, options)
 	return resource.Shop, err
 }

--- a/shop_test.go
+++ b/shop_test.go
@@ -12,7 +12,7 @@ func TestShopGet(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/shop.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/shop.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("shop.json")))
 
 	shop, err := client.Shop.Get(nil)

--- a/smartcollection.go
+++ b/smartcollection.go
@@ -65,7 +65,7 @@ type SmartCollectionsResource struct {
 
 // List smart collections
 func (s *SmartCollectionServiceOp) List(options interface{}) ([]SmartCollection, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, smartCollectionsBasePath)
+	path := fmt.Sprintf("%s.json", smartCollectionsBasePath)
 	resource := new(SmartCollectionsResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Collections, err
@@ -73,13 +73,13 @@ func (s *SmartCollectionServiceOp) List(options interface{}) ([]SmartCollection,
 
 // Count smart collections
 func (s *SmartCollectionServiceOp) Count(options interface{}) (int, error) {
-	path := fmt.Sprintf("%s/%s/count.json", globalApiPathPrefix, smartCollectionsBasePath)
+	path := fmt.Sprintf("%s/count.json", smartCollectionsBasePath)
 	return s.client.Count(path, options)
 }
 
 // Get individual smart collection
 func (s *SmartCollectionServiceOp) Get(collectionID int64, options interface{}) (*SmartCollection, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, smartCollectionsBasePath, collectionID)
+	path := fmt.Sprintf("%s/%d.json", smartCollectionsBasePath, collectionID)
 	resource := new(SmartCollectionResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Collection, err
@@ -88,7 +88,7 @@ func (s *SmartCollectionServiceOp) Get(collectionID int64, options interface{}) 
 // Create a new smart collection
 // See Image for the details of the Image creation for a collection.
 func (s *SmartCollectionServiceOp) Create(collection SmartCollection) (*SmartCollection, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, smartCollectionsBasePath)
+	path := fmt.Sprintf("%s.json", smartCollectionsBasePath)
 	wrappedData := SmartCollectionResource{Collection: &collection}
 	resource := new(SmartCollectionResource)
 	err := s.client.Post(path, wrappedData, resource)
@@ -97,7 +97,7 @@ func (s *SmartCollectionServiceOp) Create(collection SmartCollection) (*SmartCol
 
 // Update an existing smart collection
 func (s *SmartCollectionServiceOp) Update(collection SmartCollection) (*SmartCollection, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, smartCollectionsBasePath, collection.ID)
+	path := fmt.Sprintf("%s/%d.json", smartCollectionsBasePath, collection.ID)
 	wrappedData := SmartCollectionResource{Collection: &collection}
 	resource := new(SmartCollectionResource)
 	err := s.client.Put(path, wrappedData, resource)
@@ -106,7 +106,7 @@ func (s *SmartCollectionServiceOp) Update(collection SmartCollection) (*SmartCol
 
 // Delete an existing smart collection.
 func (s *SmartCollectionServiceOp) Delete(collectionID int64) error {
-	return s.client.Delete(fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, smartCollectionsBasePath, collectionID))
+	return s.client.Delete(fmt.Sprintf("%s/%d.json", smartCollectionsBasePath, collectionID))
 }
 
 // List metafields for a smart collection

--- a/smartcollection_test.go
+++ b/smartcollection_test.go
@@ -38,7 +38,7 @@ func TestSmartCollectionList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/smart_collections.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/smart_collections.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"smart_collections": [{"id":1},{"id":2}]}`))
 
 	collections, err := client.SmartCollection.List(nil)
@@ -56,13 +56,13 @@ func TestSmartCollectionCount(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/smart_collections/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/smart_collections/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 5}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/smart_collections/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/smart_collections/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -92,7 +92,7 @@ func TestSmartCollectionGet(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/smart_collections/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/smart_collections/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"smart_collection": {"id":1}}`))
 
 	collection, err := client.SmartCollection.Get(1, nil)
@@ -110,7 +110,7 @@ func TestSmartCollectionCreate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/smart_collections.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/smart_collections.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("smartcollection.json")))
 
 	collection := SmartCollection{
@@ -129,7 +129,7 @@ func TestSmartCollectionUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/smart_collections/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/smart_collections/1.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("smartcollection.json")))
 
 	collection := SmartCollection{
@@ -149,7 +149,7 @@ func TestSmartCollectionDelete(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/smart_collections/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/smart_collections/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.SmartCollection.Delete(1)
@@ -162,7 +162,7 @@ func TestSmartCollectionListMetafields(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"metafields": [{"id":1},{"id":2}]}`))
 
 	metafields, err := client.SmartCollection.ListMetafields(1, nil)
@@ -180,13 +180,13 @@ func TestSmartCollectionCountMetafields(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 3}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -216,7 +216,7 @@ func TestSmartCollectionGetMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"metafield": {"id":2}}`))
 
 	metafield, err := client.SmartCollection.GetMetafield(1, 2, nil)
@@ -234,7 +234,7 @@ func TestSmartCollectionCreateMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
 
 	metafield := Metafield{
@@ -256,7 +256,7 @@ func TestSmartCollectionUpdateMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
 
 	metafield := Metafield{
@@ -279,7 +279,7 @@ func TestSmartCollectionDeleteMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/collections/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.SmartCollection.DeleteMetafield(1, 2)

--- a/storefrontaccesstoken.go
+++ b/storefrontaccesstoken.go
@@ -44,7 +44,7 @@ type StorefrontAccessTokensResource struct {
 
 // List storefront access tokens
 func (s *StorefrontAccessTokenServiceOp) List(options interface{}) ([]StorefrontAccessToken, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, storefrontAccessTokensBasePath)
+	path := fmt.Sprintf("%s.json", storefrontAccessTokensBasePath)
 	resource := new(StorefrontAccessTokensResource)
 	err := s.client.Get(path, resource, options)
 	return resource.StorefrontAccessTokens, err
@@ -52,7 +52,7 @@ func (s *StorefrontAccessTokenServiceOp) List(options interface{}) ([]Storefront
 
 // Create a new storefront access token
 func (s *StorefrontAccessTokenServiceOp) Create(storefrontAccessToken StorefrontAccessToken) (*StorefrontAccessToken, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, storefrontAccessTokensBasePath)
+	path := fmt.Sprintf("%s.json", storefrontAccessTokensBasePath)
 	wrappedData := StorefrontAccessTokenResource{StorefrontAccessToken: &storefrontAccessToken}
 	resource := new(StorefrontAccessTokenResource)
 	err := s.client.Post(path, wrappedData, resource)
@@ -61,5 +61,5 @@ func (s *StorefrontAccessTokenServiceOp) Create(storefrontAccessToken Storefront
 
 // Delete an existing storefront access token
 func (s *StorefrontAccessTokenServiceOp) Delete(ID int64) error {
-	return s.client.Delete(fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, storefrontAccessTokensBasePath, ID))
+	return s.client.Delete(fmt.Sprintf("%s/%d.json", storefrontAccessTokensBasePath, ID))
 }

--- a/storefrontaccesstoken_test.go
+++ b/storefrontaccesstoken_test.go
@@ -39,7 +39,7 @@ func TestStorefrontAccessTokenList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/storefront_access_tokens.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/storefront_access_tokens.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("storefront_access_tokens.json")))
 
 	storefrontAccessTokens, err := client.StorefrontAccessToken.List(nil)
@@ -58,7 +58,7 @@ func TestStorefrontAccessTokenCreate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/storefront_access_tokens.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/storefront_access_tokens.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("storefront_access_token.json")))
 
 	storefrontAccessToken := StorefrontAccessToken{
@@ -77,7 +77,7 @@ func TestStorefrontAccessTokenDelete(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/storefront_access_tokens/755357713.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/storefront_access_tokens/755357713.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.StorefrontAccessToken.Delete(755357713)

--- a/theme.go
+++ b/theme.go
@@ -45,8 +45,40 @@ type ThemesResource struct {
 
 // List all themes
 func (s *ThemeServiceOp) List(options interface{}) ([]Theme, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, themesBasePath)
+	path := fmt.Sprintf("%s.json", themesBasePath)
 	resource := new(ThemesResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Themes, err
+}
+
+// Update a theme
+func (s *ThemeServiceOp) Create(theme Theme) (*Theme, error) {
+	path := fmt.Sprintf("%s.json", themesBasePath)
+	wrappedData := ThemeResource{Theme: &theme}
+	resource := new(ThemeResource)
+	err := s.client.Post(path, wrappedData, resource)
+	return resource.Theme, err
+}
+
+// Get a theme
+func (s *ThemeServiceOp) Get(themeID int64, options interface{}) (*Theme, error) {
+	path := fmt.Sprintf("%s/%d.json", themesBasePath, themeID)
+	resource := new(ThemeResource)
+	err := s.client.Get(path, resource, options)
+	return resource.Theme, err
+}
+
+// Update a theme
+func (s *ThemeServiceOp) Update(theme Theme) (*Theme, error) {
+	path := fmt.Sprintf("%s/%d.json", themesBasePath, theme.ID)
+	wrappedData := ThemeResource{Theme: &theme}
+	resource := new(ThemeResource)
+	err := s.client.Put(path, wrappedData, resource)
+	return resource.Theme, err
+}
+
+// Delete a theme
+func (s *ThemeServiceOp) Delete(themeID int64) error {
+	path := fmt.Sprintf("%s/%d.json", themesBasePath, themeID)
+	return s.client.Delete(path)
 }

--- a/theme_test.go
+++ b/theme_test.go
@@ -14,7 +14,7 @@ func TestThemeList(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/themes.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/themes.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(
 			200,
 			`{"themes": [{"id":1},{"id":2}]}`,
@@ -24,7 +24,7 @@ func TestThemeList(t *testing.T) {
 	params := map[string]string{"role": "main"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/themes.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/themes.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(
 			200,
@@ -50,5 +50,102 @@ func TestThemeList(t *testing.T) {
 	expected = []Theme{{ID: 1}}
 	if !reflect.DeepEqual(themes, expected) {
 		t.Errorf("Theme.List returned %+v, expected %+v", themes, expected)
+	}
+}
+
+func TestThemeGet(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("GET",
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/%s/1.json", defaultApiPathPrefix, themesBasePath),
+		httpmock.NewBytesResponder(200, loadFixture("theme.json")))
+
+	theme, err := client.Theme.Get(1, nil)
+	if err != nil {
+		t.Errorf("Theme.Get returned error: %v", err)
+	}
+
+	expectation := getTheme()
+	if theme.ID != expectation.ID {
+		t.Errorf("Theme.ID returned %+v, expected %+v", theme.ID, expectation.ID)
+	}
+	if theme.Name != expectation.Name {
+		t.Errorf("Theme.Name returned %+v, expected %+v", theme.Name, expectation.Name)
+	}
+	if theme.Previewable != expectation.Previewable {
+		t.Errorf("Theme.Previewable returned %+v, expected %+v", theme.Previewable, expectation.Previewable)
+	}
+	if theme.Processing != expectation.Processing {
+		t.Errorf("Theme.Processing returned %+v, expected %+v", theme.Processing, expectation.Processing)
+	}
+	if theme.Role != expectation.Role {
+		t.Errorf("Theme.Role returned %+v, expected %+v", theme.Role, expectation.Role)
+	}
+	if theme.ThemeStoreID != expectation.ThemeStoreID {
+		t.Errorf("Theme.ThemeStoreID returned %+v, expected %+v", theme.ThemeStoreID, expectation.ThemeStoreID)
+	}
+	if !theme.CreatedAt.Equal(*expectation.CreatedAt) {
+		t.Errorf("Theme.CreatedAt returned %+v, expected %+v", theme.CreatedAt, expectation.CreatedAt)
+	}
+	if !theme.UpdatedAt.Equal(*expectation.UpdatedAt) {
+		t.Errorf("Theme.UpdatedAt returned %+v, expected %+v", theme.UpdatedAt, expectation.UpdatedAt)
+	}
+	if theme.AdminGraphQLApiID != expectation.AdminGraphQLApiID {
+		t.Errorf("Theme.AdminGraphQLApiID returned %+v, expected %+v", theme.AdminGraphQLApiID, expectation.AdminGraphQLApiID)
+	}
+}
+
+func TestThemeUpdate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("PUT",
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/%s/1.json", defaultApiPathPrefix, themesBasePath),
+		httpmock.NewBytesResponder(200, loadFixture("theme.json")))
+
+	theme := getTheme()
+	expectation, err := client.Theme.Update(theme)
+	if err != nil {
+		t.Errorf("Theme.Update returned error: %v", err)
+	}
+
+	expectedThemeID := int64(1)
+	if expectation.ID != expectedThemeID {
+		t.Errorf("Theme.ID returned %+v expected %+v", expectation.ID, expectedThemeID)
+	}
+}
+
+func TestThemeCreate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("POST",
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/%s.json", defaultApiPathPrefix, themesBasePath),
+		httpmock.NewBytesResponder(200, loadFixture("theme.json")))
+
+	theme := getTheme()
+	expectation, err := client.Theme.Create(theme)
+	if err != nil {
+		t.Errorf("Theme.Create returned error: %v", err)
+	}
+
+	expectedThemeID := int64(1)
+	if expectation.ID != expectedThemeID {
+		t.Errorf("Theme.ID returned %+v expected %+v", expectation.ID, expectedThemeID)
+	}
+}
+
+func TestThemeDelete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("DELETE",
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/%s/1.json", defaultApiPathPrefix, themesBasePath),
+		httpmock.NewStringResponder(200, ""))
+
+	err := client.Theme.Delete(1)
+	if err != nil {
+		t.Errorf("Theme.Delete returned error: %v", err)
 	}
 }

--- a/transaction.go
+++ b/transaction.go
@@ -30,7 +30,7 @@ type TransactionsResource struct {
 
 // List transactions
 func (s *TransactionServiceOp) List(orderID int64, options interface{}) ([]Transaction, error) {
-	path := fmt.Sprintf("%s/%s/%d/transactions.json", globalApiPathPrefix, ordersBasePath, orderID)
+	path := fmt.Sprintf("%s/%d/transactions.json", ordersBasePath, orderID)
 	resource := new(TransactionsResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Transactions, err
@@ -38,13 +38,13 @@ func (s *TransactionServiceOp) List(orderID int64, options interface{}) ([]Trans
 
 // Count transactions
 func (s *TransactionServiceOp) Count(orderID int64, options interface{}) (int, error) {
-	path := fmt.Sprintf("%s/%s/%d/transactions/count.json", globalApiPathPrefix, ordersBasePath, orderID)
+	path := fmt.Sprintf("%s/%d/transactions/count.json", ordersBasePath, orderID)
 	return s.client.Count(path, options)
 }
 
 // Get individual transaction
 func (s *TransactionServiceOp) Get(orderID int64, transactionID int64, options interface{}) (*Transaction, error) {
-	path := fmt.Sprintf("%s/%s/%d/transactions/%d.json", globalApiPathPrefix, ordersBasePath, orderID, transactionID)
+	path := fmt.Sprintf("%s/%d/transactions/%d.json", ordersBasePath, orderID, transactionID)
 	resource := new(TransactionResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Transaction, err
@@ -52,7 +52,7 @@ func (s *TransactionServiceOp) Get(orderID int64, transactionID int64, options i
 
 // Create a new transaction
 func (s *TransactionServiceOp) Create(orderID int64, transaction Transaction) (*Transaction, error) {
-	path := fmt.Sprintf("%s/%s/%d/transactions.json", globalApiPathPrefix, ordersBasePath, orderID)
+	path := fmt.Sprintf("%s/%d/transactions.json", ordersBasePath, orderID)
 	wrappedData := TransactionResource{Transaction: &transaction}
 	resource := new(TransactionResource)
 	err := s.client.Post(path, wrappedData, resource)

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -131,7 +131,7 @@ func TestTransactionList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/transactions.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/transactions.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("transactions.json")))
 
 	transactions, err := client.Transaction.List(1, nil)
@@ -148,7 +148,7 @@ func TestTransactionCount(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/transactions/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/transactions/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
 	cnt, err := client.Transaction.Count(1, nil)
@@ -166,7 +166,7 @@ func TestTransactionGet(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/transactions/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/transactions/1.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("transaction.json")))
 
 	transaction, err := client.Transaction.Get(1, 1, nil)
@@ -181,7 +181,7 @@ func TestTransactionCreate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/transactions.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/orders/1/transactions.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("transaction.json")))
 
 	amount := decimal.NewFromFloat(409.94)

--- a/usagecharge.go
+++ b/usagecharge.go
@@ -73,7 +73,7 @@ type UsageChargesResource struct {
 func (r *UsageChargeServiceOp) Create(chargeID int64, usageCharge UsageCharge) (
 	*UsageCharge, error) {
 
-	path := fmt.Sprintf("%s/%s/%d/%s.json", globalApiPathPrefix, recurringApplicationChargesBasePath, chargeID, usageChargesPath)
+	path := fmt.Sprintf("%s/%d/%s.json", recurringApplicationChargesBasePath, chargeID, usageChargesPath)
 	wrappedData := UsageChargeResource{Charge: &usageCharge}
 	resource := &UsageChargeResource{}
 	err := r.client.Post(path, wrappedData, resource)
@@ -84,7 +84,7 @@ func (r *UsageChargeServiceOp) Create(chargeID int64, usageCharge UsageCharge) (
 func (r *UsageChargeServiceOp) Get(chargeID int64, usageChargeID int64, options interface{}) (
 	*UsageCharge, error) {
 
-	path := fmt.Sprintf("%s/%s/%d/%s/%d.json", globalApiPathPrefix, recurringApplicationChargesBasePath, chargeID, usageChargesPath, usageChargeID)
+	path := fmt.Sprintf("%s/%d/%s/%d.json", recurringApplicationChargesBasePath, chargeID, usageChargesPath, usageChargeID)
 	resource := &UsageChargeResource{}
 	err := r.client.Get(path, resource, options)
 	return resource.Charge, err
@@ -94,7 +94,7 @@ func (r *UsageChargeServiceOp) Get(chargeID int64, usageChargeID int64, options 
 func (r *UsageChargeServiceOp) List(chargeID int64, options interface{}) (
 	[]UsageCharge, error) {
 
-	path := fmt.Sprintf("%s/%s/%d/%s.json", globalApiPathPrefix, recurringApplicationChargesBasePath, chargeID, usageChargesPath)
+	path := fmt.Sprintf("%s/%d/%s.json", recurringApplicationChargesBasePath, chargeID, usageChargesPath)
 	resource := &UsageChargesResource{}
 	err := r.client.Get(path, resource, options)
 	return resource.Charges, err

--- a/usagecharge_test.go
+++ b/usagecharge_test.go
@@ -40,7 +40,7 @@ func TestUsageChargeServiceOp_Create(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"POST",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/455696195/usage_charges.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/455696195/usage_charges.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(
 			200, loadFixture("usagecharge.json"),
 		),
@@ -66,7 +66,7 @@ func TestUsageChargeServiceOp_Get(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/455696195/usage_charges/1034618210.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/455696195/usage_charges/1034618210.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(
 			200, loadFixture("usagecharge.json"),
 		),
@@ -86,7 +86,7 @@ func TestUsageChargeServiceOp_List(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/455696195/usage_charges.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/455696195/usage_charges.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(
 			200, loadFixture("usagecharges.json"),
 		),
@@ -112,7 +112,7 @@ func TestUsageChargeServiceOp_GetBadFields(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/455696195/usage_charges/1034618210.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/455696195/usage_charges/1034618210.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(
 			200, `{"usage_charge":{"id":"wrong_id_type"}}`,
 		),
@@ -124,7 +124,7 @@ func TestUsageChargeServiceOp_GetBadFields(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/455696195/usage_charges/1034618210.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/455696195/usage_charges/1034618210.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(
 			200, `{"usage_charge":{"billing_on":"2018-14-01"}}`,
 		),

--- a/util.go
+++ b/util.go
@@ -31,22 +31,18 @@ func ShopBaseUrl(name string) string {
 
 // Return the prefix for a metafield path
 func MetafieldPathPrefix(resource string, resourceID int64) string {
-	var prefix string
-	if resource == "" {
-		prefix = fmt.Sprintf("%s/metafields", globalApiPathPrefix)
-	} else {
-		prefix = fmt.Sprintf("%s/%s/%d/metafields", globalApiPathPrefix, resource, resourceID)
+	prefix := "metafields"
+	if resource != "" {
+		prefix = fmt.Sprintf("%s/%d/metafields", resource, resourceID)
 	}
 	return prefix
 }
 
 // Return the prefix for a fulfillment path
 func FulfillmentPathPrefix(resource string, resourceID int64) string {
-	var prefix string
-	if resource == "" {
-		prefix = fmt.Sprintf("%s/fulfillments", globalApiPathPrefix)
-	} else {
-		prefix = fmt.Sprintf("%s/%s/%d/fulfillments", globalApiPathPrefix, resource, resourceID)
+	prefix := "fulfillments"
+	if resource != "" {
+		prefix = fmt.Sprintf("%s/%d/fulfillments", resource, resourceID)
 	}
 	return prefix
 }

--- a/util_test.go
+++ b/util_test.go
@@ -72,8 +72,8 @@ func TestMetafieldPathPrefix(t *testing.T) {
 		resourceID int64
 		expected   string
 	}{
-		{"", 0, fmt.Sprintf("%s/metafields", globalApiPathPrefix)},
-		{"products", 123, fmt.Sprintf("%s/products/123/metafields", globalApiPathPrefix)},
+		{"", 0, fmt.Sprintf("%s/metafields", defaultApiPathPrefix)},
+		{"products", 123, fmt.Sprintf("%s/products/123/metafields", defaultApiPathPrefix)},
 	}
 
 	for _, c := range cases {
@@ -90,8 +90,8 @@ func TestFulfillmentPathPrefix(t *testing.T) {
 		resourceID int64
 		expected   string
 	}{
-		{"", 0, fmt.Sprintf("%s/fulfillments", globalApiPathPrefix)},
-		{"orders", 123, fmt.Sprintf("%s/orders/123/fulfillments", globalApiPathPrefix)},
+		{"", 0, fmt.Sprintf("%s/fulfillments", defaultApiPathPrefix)},
+		{"orders", 123, fmt.Sprintf("%s/orders/123/fulfillments", defaultApiPathPrefix)},
 	}
 
 	for _, c := range cases {

--- a/variant.go
+++ b/variant.go
@@ -75,7 +75,7 @@ type VariantsResource struct {
 
 // List variants
 func (s *VariantServiceOp) List(productID int64, options interface{}) ([]Variant, error) {
-	path := fmt.Sprintf("%s/%s/%d/variants.json", globalApiPathPrefix, productsBasePath, productID)
+	path := fmt.Sprintf("%s/%d/variants.json", productsBasePath, productID)
 	resource := new(VariantsResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Variants, err
@@ -83,13 +83,13 @@ func (s *VariantServiceOp) List(productID int64, options interface{}) ([]Variant
 
 // Count variants
 func (s *VariantServiceOp) Count(productID int64, options interface{}) (int, error) {
-	path := fmt.Sprintf("%s/%s/%d/variants/count.json", globalApiPathPrefix, productsBasePath, productID)
+	path := fmt.Sprintf("%s/%d/variants/count.json", productsBasePath, productID)
 	return s.client.Count(path, options)
 }
 
 // Get individual variant
 func (s *VariantServiceOp) Get(variantID int64, options interface{}) (*Variant, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, variantsBasePath, variantID)
+	path := fmt.Sprintf("%s/%d.json", variantsBasePath, variantID)
 	resource := new(VariantResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Variant, err
@@ -97,7 +97,7 @@ func (s *VariantServiceOp) Get(variantID int64, options interface{}) (*Variant, 
 
 // Create a new variant
 func (s *VariantServiceOp) Create(productID int64, variant Variant) (*Variant, error) {
-	path := fmt.Sprintf("%s/%s/%d/variants.json", globalApiPathPrefix, productsBasePath, productID)
+	path := fmt.Sprintf("%s/%d/variants.json", productsBasePath, productID)
 	wrappedData := VariantResource{Variant: &variant}
 	resource := new(VariantResource)
 	err := s.client.Post(path, wrappedData, resource)
@@ -106,7 +106,7 @@ func (s *VariantServiceOp) Create(productID int64, variant Variant) (*Variant, e
 
 // Update existing variant
 func (s *VariantServiceOp) Update(variant Variant) (*Variant, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, variantsBasePath, variant.ID)
+	path := fmt.Sprintf("%s/%d.json", variantsBasePath, variant.ID)
 	wrappedData := VariantResource{Variant: &variant}
 	resource := new(VariantResource)
 	err := s.client.Put(path, wrappedData, resource)
@@ -115,7 +115,7 @@ func (s *VariantServiceOp) Update(variant Variant) (*Variant, error) {
 
 // Delete an existing variant
 func (s *VariantServiceOp) Delete(productID int64, variantID int64) error {
-	return s.client.Delete(fmt.Sprintf("%s/%s/%d/variants/%d.json", globalApiPathPrefix, productsBasePath, productID, variantID))
+	return s.client.Delete(fmt.Sprintf("%s/%d/variants/%d.json", productsBasePath, productID, variantID))
 }
 
 // ListMetafields for a variant

--- a/variant_test.go
+++ b/variant_test.go
@@ -67,7 +67,7 @@ func TestVariantList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/variants.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/variants.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"variants": [{"id":1},{"id":2}]}`))
 
 	variants, err := client.Variant.List(1, nil)
@@ -85,13 +85,13 @@ func TestVariantCount(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/variants/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/variants/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 3}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/variants/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/variants/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -121,7 +121,7 @@ func TestVariantGet(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"variant": {"id":1}}`))
 
 	variant, err := client.Variant.Get(1, nil)
@@ -139,7 +139,7 @@ func TestVariantCreate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/variants.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/variants.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("variant.json")))
 
 	price := decimal.NewFromFloat(1)
@@ -159,7 +159,7 @@ func TestVariantCreateWithMetafields(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/variants.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/variants.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("variant_with_metafields.json")))
 
 	price := decimal.NewFromFloat(2)
@@ -179,7 +179,7 @@ func TestVariantUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("variant.json")))
 
 	variant := Variant{
@@ -200,7 +200,7 @@ func TestVariantWithMetafieldsUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/2.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("variant_with_metafields.json")))
 
 	variant := Variant{
@@ -229,7 +229,7 @@ func TestVariantDelete(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/variants/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/variants/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.Variant.Delete(1, 1)
@@ -242,7 +242,7 @@ func TestVariantListMetafields(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1/metafields.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1/metafields.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"metafields": [{"id":1},{"id":2}]}`))
 
 	metafields, err := client.Variant.ListMetafields(1, nil)
@@ -260,13 +260,13 @@ func TestVariantCountMetafields(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1/metafields/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1/metafields/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 3}`))
 
 	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1/metafields/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1/metafields/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -296,7 +296,7 @@ func TestVariantGetMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"metafield": {"id":2}}`))
 
 	metafield, err := client.Variant.GetMetafield(1, 2, nil)
@@ -314,7 +314,7 @@ func TestVariantCreateMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1/metafields.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1/metafields.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
 
 	metafield := Metafield{
@@ -336,7 +336,7 @@ func TestVariantUpdateMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
 
 	metafield := Metafield{
@@ -359,7 +359,7 @@ func TestVariantDeleteMetafield(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1/metafields/2.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1/metafields/2.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.Variant.DeleteMetafield(1, 2)
@@ -372,7 +372,7 @@ func TestVariantListWithTaxCode(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/variants.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/variants.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"variants": [{"id":1, "tax_code":"P0000000"},{"id":2, "tax_code":"P0000000"}]}`))
 
 	variants, err := client.Variant.List(1, nil)
@@ -390,7 +390,7 @@ func TestVariantGetWithTaxCode(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/1.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"variant": {"id":1, "tax_code":"P0000000"}}`))
 
 	variant, err := client.Variant.Get(1, nil)
@@ -408,7 +408,7 @@ func TestVariantCreateWithTaxCode(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/variants.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1/variants.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("variant_with_taxcode.json")))
 
 	price := decimal.NewFromFloat(1)

--- a/webhook.go
+++ b/webhook.go
@@ -55,7 +55,7 @@ type WebhooksResource struct {
 
 // List webhooks
 func (s *WebhookServiceOp) List(options interface{}) ([]Webhook, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, webhooksBasePath)
+	path := fmt.Sprintf("%s.json", webhooksBasePath)
 	resource := new(WebhooksResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Webhooks, err
@@ -63,13 +63,13 @@ func (s *WebhookServiceOp) List(options interface{}) ([]Webhook, error) {
 
 // Count webhooks
 func (s *WebhookServiceOp) Count(options interface{}) (int, error) {
-	path := fmt.Sprintf("%s/%s/count.json", globalApiPathPrefix, webhooksBasePath)
+	path := fmt.Sprintf("%s/count.json", webhooksBasePath)
 	return s.client.Count(path, options)
 }
 
 // Get individual webhook
 func (s *WebhookServiceOp) Get(webhookdID int64, options interface{}) (*Webhook, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, webhooksBasePath, webhookdID)
+	path := fmt.Sprintf("%s/%d.json", webhooksBasePath, webhookdID)
 	resource := new(WebhookResource)
 	err := s.client.Get(path, resource, options)
 	return resource.Webhook, err
@@ -77,7 +77,7 @@ func (s *WebhookServiceOp) Get(webhookdID int64, options interface{}) (*Webhook,
 
 // Create a new webhook
 func (s *WebhookServiceOp) Create(webhook Webhook) (*Webhook, error) {
-	path := fmt.Sprintf("%s/%s.json", globalApiPathPrefix, webhooksBasePath)
+	path := fmt.Sprintf("%s.json", webhooksBasePath)
 	wrappedData := WebhookResource{Webhook: &webhook}
 	resource := new(WebhookResource)
 	err := s.client.Post(path, wrappedData, resource)
@@ -86,7 +86,7 @@ func (s *WebhookServiceOp) Create(webhook Webhook) (*Webhook, error) {
 
 // Update an existing webhook.
 func (s *WebhookServiceOp) Update(webhook Webhook) (*Webhook, error) {
-	path := fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, webhooksBasePath, webhook.ID)
+	path := fmt.Sprintf("%s/%d.json", webhooksBasePath, webhook.ID)
 	wrappedData := WebhookResource{Webhook: &webhook}
 	resource := new(WebhookResource)
 	err := s.client.Put(path, wrappedData, resource)
@@ -95,5 +95,5 @@ func (s *WebhookServiceOp) Update(webhook Webhook) (*Webhook, error) {
 
 // Delete an existing webhooks
 func (s *WebhookServiceOp) Delete(ID int64) error {
-	return s.client.Delete(fmt.Sprintf("%s/%s/%d.json", globalApiPathPrefix, webhooksBasePath, ID))
+	return s.client.Delete(fmt.Sprintf("%s/%d.json", webhooksBasePath, ID))
 }

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -41,7 +41,7 @@ func TestWebhookList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/webhooks.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/webhooks.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("webhooks.json")))
 
 	webhooks, err := client.Webhook.List(nil)
@@ -61,7 +61,7 @@ func TestWebhookGet(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/webhooks/4759306.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/webhooks/4759306.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("webhook.json")))
 
 	webhook, err := client.Webhook.Get(4759306, nil)
@@ -76,13 +76,13 @@ func TestWebhookCount(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/webhooks/count.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/webhooks/count.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, `{"count": 7}`))
 
 	params := map[string]string{"topic": "orders/paid"}
 	httpmock.RegisterResponderWithQuery(
 		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/webhooks/count.json", globalApiPathPrefix),
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/webhooks/count.json", defaultApiPathPrefix),
 		params,
 		httpmock.NewStringResponder(200, `{"count": 2}`))
 
@@ -112,7 +112,7 @@ func TestWebhookCreate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/webhooks.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/webhooks.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("webhook.json")))
 
 	webhook := Webhook{
@@ -132,7 +132,7 @@ func TestWebhookUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/webhooks/4759306.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/webhooks/4759306.json", defaultApiPathPrefix),
 		httpmock.NewBytesResponder(200, loadFixture("webhook.json")))
 
 	webhook := Webhook{
@@ -153,7 +153,7 @@ func TestWebhookDelete(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/webhooks/4759306.json", globalApiPathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/webhooks/4759306.json", defaultApiPathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.Webhook.Delete(4759306)


### PR DESCRIPTION
* moves globalApiPreix for Client.apiPrefix so you can make two clients using different versions.
* tracks API Version in Client.apiVersion, defaults to "stable" and will update on first request to keep track of it.
* changed from using http.DefaultClient to creating a new type &http.Client, not good practice to use DefaultClient in a large project in case someone uses it behind your back and changes your settings.

Closes #80 