### PR TITLE
Add support for pagination via header refactored

### DIFF
--- a/goshopify.go
+++ b/goshopify.go
@@ -290,15 +290,25 @@ func NewClient(app App, shopName, token string, opts ...Option) *Client {
 // response. It does not make much sense to call Do without a prepared
 // interface instance.
 func (c *Client) Do(req *http.Request, v interface{}) error {
-	resp, err := c.Client.Do(req)
+	_, err := c.doGetHeaders(req, v)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// doGetHeaders executes a request, decoding the response into `v` and also returns any response headers.
+func (c *Client) doGetHeaders(req *http.Request, v interface{}) (http.Header, error) {
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	err = CheckResponseError(resp)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if c.apiVersion == defaultApiVersion && resp.Header.Get("X-Shopify-API-Version") != "" {
@@ -310,11 +320,11 @@ func (c *Client) Do(req *http.Request, v interface{}) error {
 		decoder := json.NewDecoder(resp.Body)
 		err := decoder.Decode(&v)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return nil
+	return resp.Header, nil
 }
 
 func wrapSpecificError(r *http.Response, err ResponseError) error {
@@ -420,6 +430,12 @@ func CheckResponseError(r *http.Response) error {
 
 // General list options that can be used for most collections of entities.
 type ListOptions struct {
+
+	// PageInfo is used with new pagination search.
+	PageInfo string `url:"page_info,omitempty"`
+
+	// Page is used to specify a specific page to load.
+	// It is the deprecated way to do pagination.
 	Page         int       `url:"page,omitempty"`
 	Limit        int       `url:"limit,omitempty"`
 	SinceID      int64     `url:"since_id,omitempty"`
@@ -459,6 +475,15 @@ func (c *Client) Count(path string, options interface{}) (int, error) {
 // parameters like created_at_min
 // Any data returned from Shopify will be marshalled into resource argument.
 func (c *Client) CreateAndDo(method, relPath string, data, options, resource interface{}) error {
+	_, err := c.createAndDoGetHeaders(method, relPath, data, options, resource)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// createAndDoGetHeaders creates an executes a request while returning the response headers.
+func (c *Client) createAndDoGetHeaders(method, relPath string, data, options, resource interface{}) (http.Header, error) {
 	if strings.HasPrefix(relPath, "/") {
 		// make sure it's a relative path
 		relPath = strings.TrimLeft(relPath, "/")
@@ -467,15 +492,10 @@ func (c *Client) CreateAndDo(method, relPath string, data, options, resource int
 	relPath = path.Join(c.pathPrefix, relPath)
 	req, err := c.NewRequest(method, relPath, data, options)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	err = c.Do(req, resource)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return c.doGetHeaders(req, resource)
 }
 
 // Get performs a GET request for the given path and saves the result in the

--- a/goshopify_test.go
+++ b/goshopify_test.go
@@ -356,9 +356,12 @@ func TestDo(t *testing.T) {
 		httpmock.RegisterResponder("GET", shopUrl, c.responder)
 
 		body := new(MyStruct)
-		req, _ := client.NewRequest("GET", c.url, nil, nil)
-		err := client.Do(req, body)
+		req, err := client.NewRequest("GET", c.url, nil, nil)
+		if err != nil {
+			t.Error("error creating request: ", err)
+		}
 
+		err = client.Do(req, body)
 		if err != nil {
 			if e, ok := err.(*url.Error); ok {
 				err = e.Err

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -51,6 +51,20 @@ func TestAppGetAccessToken(t *testing.T) {
 	}
 }
 
+func TestAppGetAccessTokenError(t *testing.T) {
+	setup()
+	defer teardown()
+
+	// app.Client isn't specified so NewClient called
+	expectedError := errors.New("invalid_request")
+
+	_, err := app.GetAccessToken("fooshop", "")
+
+	if err == nil || err.Error() != expectedError.Error() {
+		t.Errorf("Expected error %s got error %s", expectedError.Error(), err.Error())
+	}
+}
+
 func TestAppVerifyAuthorizationURL(t *testing.T) {
 	// These credentials are from the Shopify example page:
 	// https://help.shopify.com/api/guides/authentication/oauth#verification

--- a/product.go
+++ b/product.go
@@ -130,7 +130,7 @@ func (s *ProductServiceOp) ListWithPagination(options interface{}) ([]Product, *
 	return resource.Products, pagination, nil
 }
 
-// Extract pagination from the Link header
+// extractPagination extracts pagination info from linkHeader.
 // Details on the format are here:
 // https://help.shopify.com/en/api/guides/paginated-rest-results
 func extractPagination(linkHeader string) (*Pagination, error) {

--- a/product.go
+++ b/product.go
@@ -176,7 +176,13 @@ func extractPagination(linkHeader string) (*Pagination, error) {
 			return nil, err
 		}
 
-		paginationListOptions.Limit, _ = strconv.Atoi(params.Get("limit"))
+		limit := params.Get("limit")
+		if limit != "" {
+			paginationListOptions.Limit, err = strconv.Atoi(params.Get("limit"))
+			if err != nil {
+				return nil, err
+			}
+		}
 
 		// 'rel' is either next or previous
 		if match[2] == "next" {

--- a/product.go
+++ b/product.go
@@ -2,17 +2,26 @@ package goshopify
 
 import (
 	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 )
 
 const productsBasePath = "products"
 const productsResourceName = "products"
 
+// linkRegex is used to extract pagination links from product search results.
+var linkRegex = regexp.MustCompile(`^ *<([^>]+)>; rel="(previous|next)" *$`)
+
 // ProductService is an interface for interfacing with the product endpoints
 // of the Shopify API.
 // See: https://help.shopify.com/api/reference/product
 type ProductService interface {
 	List(interface{}) ([]Product, error)
+	ListWithPagination(interface{}) ([]Product, *Pagination, error)
 	Count(interface{}) (int, error)
 	Get(int64, interface{}) (*Product, error)
 	Create(Product) (*Product, error)
@@ -84,12 +93,100 @@ type ProductsResource struct {
 	Products []Product `json:"products"`
 }
 
+// Pagination of results
+type Pagination struct {
+	NextPageOptions     *ListOptions
+	PreviousPageOptions *ListOptions
+}
+
 // List products
 func (s *ProductServiceOp) List(options interface{}) ([]Product, error) {
+	products, _, err := s.ListWithPagination(options)
+	if err != nil {
+		return nil, err
+	}
+	return products, nil
+}
+
+// ListWithPagination lists products and return pagination to retrieve next/previous results.
+func (s *ProductServiceOp) ListWithPagination(options interface{}) ([]Product, *Pagination, error) {
 	path := fmt.Sprintf("%s.json", productsBasePath)
 	resource := new(ProductsResource)
-	err := s.client.Get(path, resource, options)
-	return resource.Products, err
+	headers := http.Header{}
+
+	headers, err := s.client.createAndDoGetHeaders("GET", path, nil, options, resource)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Extract pagination info from header
+	linkHeader := headers.Get("Link")
+
+	pagination, err := extractPagination(linkHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return resource.Products, pagination, nil
+}
+
+// Extract pagination from the Link header
+// Details on the format are here:
+// https://help.shopify.com/en/api/guides/paginated-rest-results
+func extractPagination(linkHeader string) (*Pagination, error) {
+	pagination := new(Pagination)
+
+	if linkHeader == "" {
+		return pagination, nil
+	}
+
+	for _, link := range strings.Split(linkHeader, ",") {
+		match := linkRegex.FindStringSubmatch(link)
+		// Make sure the link is not empty or invalid
+		if len(match) != 3 {
+			// We expect 3 values:
+			// match[0] = full match
+			// match[1] is the URL and match[2] is either 'previous' or 'next'
+			err := ResponseDecodingError{
+				Message: "could not extract pagination link header",
+			}
+			return nil, err
+		}
+
+		rel, err := url.Parse(match[1])
+		if err != nil {
+			err = ResponseDecodingError{
+				Message: "pagination does not contain a valid URL",
+			}
+			return nil, err
+		}
+
+		params, err := url.ParseQuery(rel.RawQuery)
+		if err != nil {
+			return nil, err
+		}
+
+		paginationListOptions := ListOptions{}
+
+		paginationListOptions.PageInfo = params.Get("page_info")
+		if paginationListOptions.PageInfo == "" {
+			err = ResponseDecodingError{
+				Message: "page_info is missing",
+			}
+			return nil, err
+		}
+
+		paginationListOptions.Limit, _ = strconv.Atoi(params.Get("limit"))
+
+		// 'rel' is either next or previous
+		if match[2] == "next" {
+			pagination.NextPageOptions = &paginationListOptions
+		} else {
+			pagination.PreviousPageOptions = &paginationListOptions
+		}
+	}
+
+	return pagination, nil
 }
 
 // Count products

--- a/product_test.go
+++ b/product_test.go
@@ -89,7 +89,7 @@ func TestProductListWithPagination(t *testing.T) {
 
 	// The strconv.Atoi error changed in go 1.8, 1.7 is still being tested/supported.
 	limitConversionErrorMessage := `strconv.Atoi: parsing "invalid": invalid syntax`
-	if runtime.Version() < "go1.8" {
+	if runtime.Version()[2:5] == "1.7" {
 		limitConversionErrorMessage = `strconv.ParseInt: parsing "invalid": invalid syntax`
 	}
 

--- a/product_test.go
+++ b/product_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -86,6 +87,12 @@ func TestProductListWithPagination(t *testing.T) {
 
 	listURL := fmt.Sprintf("https://fooshop.myshopify.com/%s/products.json", client.pathPrefix)
 
+	// The strconv.Atoi error changed in go 1.8, 1.7 is still being tested/supported.
+	limitConversionErrorMessage := `strconv.Atoi: parsing "invalid": invalid syntax`
+	if runtime.Version() < "go1.8" {
+		limitConversionErrorMessage = `strconv.ParseInt: parsing "invalid": invalid syntax`
+	}
+
 	cases := []struct {
 		body               string
 		linkHeader         string
@@ -135,7 +142,7 @@ func TestProductListWithPagination(t *testing.T) {
 			`<http://valid.url?page_info=foo&limit=invalid>; rel="next"`,
 			[]Product(nil),
 			nil,
-			errors.New(`strconv.Atoi: parsing "invalid": invalid syntax`),
+			errors.New(limitConversionErrorMessage),
 		},
 		// Valid link header responses
 		{

--- a/product_test.go
+++ b/product_test.go
@@ -72,7 +72,7 @@ func TestProductListError(t *testing.T) {
 
 	products, err := client.Product.List(nil)
 	if products != nil {
-		t.Errorf("Product.List returned products, expected nil", err)
+		t.Errorf("Product.List returned products, expected nil: %v", err)
 	}
 
 	if err == nil || err.Error() != expectedErrMessage {


### PR DESCRIPTION
See original pr https://github.com/bold-commerce/go-shopify/pull/73 from @brendankay. Most credits to him I just cleaned up some errors/header response but unfortunately botched my rebase and lost my commit on top of his. This also rebases on master so that it can be merged immediately(there were a couple conflicts).

Main differences:
 - several errors and regex cleanup(move to global instead per function call)
 - refactor header handling to just be return values since headers are never actually sent and passing around pointers to empty values in order to get a return value isn't the greatest. More importantly this moves the api changes to private methods which the current methods call so that we can keep the public api the same and not break anything. If you did want to commit to this api you could just make the new methods public to avoid breaking compatibility while exposing the new header responses required for pagination.

