### PR TITLE
Update go.mod to include major version(fix modules, pkg.go.dev)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bold-commerce/go-shopify
+module github.com/bold-commerce/go-shopify/v3
 
 go 1.13
 


### PR DESCRIPTION
When using go modules you have to include the major version prefix in the module definition after v0 and v1.


https://github.com/golang/go/wiki/Modules#semantic-import-versioning

>If the module is version v2 or higher, the major version of the module must be included as a /vN at the end of the module paths used in go.mod files (e.g., module github.com/my/mod/v2, require github.com/my/mod/v2 v2.0.1) and in the package import path (e.g., import "github.com/my/mod/v2/mypkg"). This includes the paths used in go get commands (e.g., go get github.com/my/mod/v2@v2.0.1. Note there is both a /v2 and a @v2.0.1 in that example. One way to think about it is that the module name now includes the /v2, so include /v2 whenever you are using the module name).

This will fix pkg.go.dev not showing the latest docs or even allowing viewing v3. It worked on the v2.x because they weren't using modules at all but now we are basically using the module incorrectly.

https://pkg.go.dev/github.com/bold-commerce/go-shopify?tab=versions
![image](https://user-images.githubusercontent.com/5204642/76562977-de81eb00-647c-11ea-898c-bded897297ff.png)
