### PR TITLE
refactor usagecharge test, added go 1.14 and bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+dist: bionic
 go:
   - "1.7"
   - "1.8"
@@ -7,6 +8,7 @@ go:
   - "1.11"
   - "1.12"
   - "1.13"
+  - "1.14"
 script:
   - go test -coverprofile=coverage.txt
 after_success:

--- a/goshopify_test.go
+++ b/goshopify_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -558,9 +559,10 @@ func TestCreateAndDo(t *testing.T) {
 	httpmock.RegisterResponder("GET", "://fooshop.myshopify.com/foo/2", httpmock.NewStringResponder(200, ""))
 	body := new(MyStruct)
 	_, err := client.NewRequest("GET", "://fooshop.myshopify.com/foo/2", body, nil)
-	expected := errors.New("parse ://fooshop.myshopify.com/foo/2: missing protocol scheme")
 
-	if err != nil && fmt.Sprint(err) != fmt.Sprint(expected) {
+	expected := errors.New("parse \"://fooshop.myshopify.com/foo/2\": missing protocol scheme")
+
+	if err != nil && !strings.Contains(err.Error(), "missing protocol scheme") {
 		t.Errorf("CreateAndDo(): expected error %v, actual %v", expected, err)
 	} else if err == nil && !reflect.DeepEqual(body, expected) {
 		t.Errorf("CreateAndDo(): expected %#v, actual %#v", expected, body)

--- a/usagecharge_test.go
+++ b/usagecharge_test.go
@@ -2,7 +2,6 @@ package goshopify
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
@@ -11,7 +10,6 @@ import (
 )
 
 func usageChargeTests(t *testing.T, usageCharge UsageCharge) {
-
 	price := decimal.NewFromFloat(1.0)
 	createdAt, _ := time.Parse(time.RFC3339, "2018-07-05T13:05:43-04:00")
 	billingOn, _ := time.Parse("2006-01-02", "2018-08-04")
@@ -30,9 +28,31 @@ func usageChargeTests(t *testing.T, usageCharge UsageCharge) {
 		RiskLevel:        &riskLevel,
 	}
 
-	if !reflect.DeepEqual(usageCharge, expected) {
-		t.Errorf("UsageCharge.Create returned %+v, expected %+v", usageCharge, expected)
+	if usageCharge.ID != expected.ID {
+		t.Errorf("UsageCharge.ID returned %v, expected %v", usageCharge.ID, expected.ID)
 	}
+	if usageCharge.Description != expected.Description {
+		t.Errorf("UsageCharge.Description returned %v, expected %v", usageCharge.Description, expected.Description)
+	}
+	if !usageCharge.Price.Equal(*expected.Price) {
+		t.Errorf("UsageCharge.Price returned %v, expected %v", usageCharge.Price, expected.Price)
+	}
+	if !usageCharge.CreatedAt.Equal(*expected.CreatedAt) {
+		t.Errorf("UsageCharge.CreatedAt returned %v, expected %v", usageCharge.CreatedAt, expected.CreatedAt)
+	}
+	if !usageCharge.BillingOn.Equal(*expected.BillingOn) {
+		t.Errorf("UsageCharge.BillingOn returned %v, expected %v", usageCharge.BillingOn, expected.BillingOn)
+	}
+	if !usageCharge.BalanceRemaining.Equal(*expected.BalanceRemaining) {
+		t.Errorf("UsageCharge.BalanceRemaining returned %v, expected %v", usageCharge.BalanceRemaining, expected.BalanceRemaining)
+	}
+	if !usageCharge.BalanceUsed.Equal(*expected.BalanceUsed) {
+		t.Errorf("UsageCharge.BalanceUsed returned %v, expected %v", usageCharge.BalanceUsed, expected.BalanceUsed)
+	}
+	if !usageCharge.RiskLevel.Equal(*expected.RiskLevel) {
+		t.Errorf("UsageCharge.RiskLevel returned %v, expected %v", usageCharge.RiskLevel, expected.RiskLevel)
+	}
+
 }
 func TestUsageChargeServiceOp_Create(t *testing.T) {
 	setup()


### PR DESCRIPTION
Refactors the usagecharge test to not use DeepEqual any more as for some reason those tests stopped failing pre 1.13. Also added go 1.14 and updated the default build container to bionic.