### PR TITLE
Adds Discounts to LineItems and CustomerAccountActivationURL

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -85,7 +85,7 @@ type CustomerSearchOptions struct {
 }
 
 type CustomerActivation struct {
-	URL string `json:"account_activation_url,omitempty"`
+	URL *string `json:"account_activation_url,omitempty"`
 }
 
 // List customers
@@ -135,10 +135,11 @@ func (s *CustomerServiceOp) Delete(customerID int64) error {
 }
 
 // Create an account activation URL for an inactive account
-func (s *CustomerServiceOp) CreateActivationURL(customerID int64) error {
+func (s *CustomerServiceOp) CreateActivationURL(customerID int64) (*string, error) {
 	path := fmt.Sprintf("%s/%d/account_activation_url.json", customersBasePath, customerID)
 	resource := new(CustomerActivation)
-	return s.client.Post(path, nil, resource)
+	err := s.client.Post(path, nil, resource)
+	return resource.URL, err
 }
 
 // Search customers

--- a/customer.go
+++ b/customer.go
@@ -21,7 +21,7 @@ type CustomerService interface {
 	Create(Customer) (*Customer, error)
 	Update(Customer) (*Customer, error)
 	Delete(int64) error
-	CreateActivationURL(int64) error
+	CreateActivationURL(int64) (*string, error)
 	ListOrders(int64, interface{}) ([]Order, error)
 	ListTags(interface{}) ([]string, error)
 

--- a/customer.go
+++ b/customer.go
@@ -21,6 +21,7 @@ type CustomerService interface {
 	Create(Customer) (*Customer, error)
 	Update(Customer) (*Customer, error)
 	Delete(int64) error
+	CreateActivationURL(int64) error
 	ListOrders(int64, interface{}) ([]Order, error)
 	ListTags(interface{}) ([]string, error)
 
@@ -83,6 +84,10 @@ type CustomerSearchOptions struct {
 	Query  string `url:"query,omitempty"`
 }
 
+type CustomerActivation struct {
+	URL string `json:"account_activation_url,omitempty"`
+}
+
 // List customers
 func (s *CustomerServiceOp) List(options interface{}) ([]Customer, error) {
 	path := fmt.Sprintf("%s.json", customersBasePath)
@@ -127,6 +132,13 @@ func (s *CustomerServiceOp) Update(customer Customer) (*Customer, error) {
 func (s *CustomerServiceOp) Delete(customerID int64) error {
 	path := fmt.Sprintf("%s/%d.json", customersBasePath, customerID)
 	return s.client.Delete(path)
+}
+
+// Create an account activation URL for an inactive account
+func (s *CustomerServiceOp) CreateActivationURL(customerID int64) error {
+	path := fmt.Sprintf("%s/%d/account_activation_url.json", customersBasePath, customerID)
+	resource := new(CustomerActivation)
+	return s.client.Post(path, nil, resource)
 }
 
 // Search customers

--- a/customer_test.go
+++ b/customer_test.go
@@ -296,10 +296,16 @@ func TestCustomerCreateActivationURL(t *testing.T) {
 	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/account_activation_url.json", client.pathPrefix),
 		httpmock.NewStringResponder(200, `{"account_activation_url": "https://fooshop.myshopify.com/account/activate/foo/bar"}`))
 
-	err := client.Customer.CreateActivationURL(1)
+	returnedURL, err := client.Customer.CreateActivationURL(1)
 	if err != nil {
 		t.Errorf("Customer.CreateActivationURL returned error: %v", err)
 	}
+
+	expectedURL := "https://fooshop.myshopify.com/account/activate/foo/bar"
+	if returnedURL != expectedURL {
+		t.Errorf("URL returned %s expected %s", returnedURL, expectedURL)
+	}
+
 }
 
 func TestCustomerListMetafields(t *testing.T) {

--- a/customer_test.go
+++ b/customer_test.go
@@ -302,8 +302,8 @@ func TestCustomerCreateActivationURL(t *testing.T) {
 	}
 
 	expectedURL := "https://fooshop.myshopify.com/account/activate/foo/bar"
-	if returnedURL != expectedURL {
-		t.Errorf("URL returned %s expected %s", returnedURL, expectedURL)
+	if *returnedURL != expectedURL {
+		t.Errorf("URL returned %s expected %s", *returnedURL, expectedURL)
 	}
 
 }

--- a/customer_test.go
+++ b/customer_test.go
@@ -289,6 +289,19 @@ func TestCustomerDelete(t *testing.T) {
 	}
 }
 
+func TestCustomerCreateActivationURL(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/customers/1/account_activation_url.json", client.pathPrefix),
+		httpmock.NewStringResponder(200, `{"account_activation_url": "https://fooshop.myshopify.com/account/activate/foo/bar"}`))
+
+	err := client.Customer.CreateActivationURL(1)
+	if err != nil {
+		t.Errorf("Customer.CreateActivationURL returned error: %v", err)
+	}
+}
+
 func TestCustomerListMetafields(t *testing.T) {
 	setup()
 	defer teardown()

--- a/order.go
+++ b/order.go
@@ -161,32 +161,33 @@ type DiscountCode struct {
 }
 
 type LineItem struct {
-	ID                         int64            `json:"id,omitempty"`
-	ProductID                  int64            `json:"product_id,omitempty"`
-	VariantID                  int64            `json:"variant_id,omitempty"`
-	Quantity                   int              `json:"quantity,omitempty"`
-	Price                      *decimal.Decimal `json:"price,omitempty"`
-	TotalDiscount              *decimal.Decimal `json:"total_discount,omitempty"`
-	Title                      string           `json:"title,omitempty"`
-	VariantTitle               string           `json:"variant_title,omitempty"`
-	Name                       string           `json:"name,omitempty"`
-	SKU                        string           `json:"sku,omitempty"`
-	Vendor                     string           `json:"vendor,omitempty"`
-	GiftCard                   bool             `json:"gift_card,omitempty"`
-	Taxable                    bool             `json:"taxable,omitempty"`
-	FulfillmentService         string           `json:"fulfillment_service,omitempty"`
-	RequiresShipping           bool             `json:"requires_shipping,omitempty"`
-	VariantInventoryManagement string           `json:"variant_inventory_management,omitempty"`
-	PreTaxPrice                *decimal.Decimal `json:"pre_tax_price,omitempty"`
-	Properties                 []NoteAttribute  `json:"properties,omitempty"`
-	ProductExists              bool             `json:"product_exists,omitempty"`
-	FulfillableQuantity        int              `json:"fulfillable_quantity,omitempty"`
-	Grams                      int              `json:"grams,omitempty"`
-	FulfillmentStatus          string           `json:"fulfillment_status,omitempty"`
-	TaxLines                   []TaxLine        `json:"tax_lines,omitempty"`
-	OriginLocation             *Address         `json:"origin_location,omitempty"`
-	DestinationLocation        *Address         `json:"destination_location,omitempty"`
-	AppliedDiscount            *AppliedDiscount `json:"applied_discount,omitempty"`
+	ID                         int64            	`json:"id,omitempty"`
+	ProductID                  int64            	`json:"product_id,omitempty"`
+	VariantID                  int64            	`json:"variant_id,omitempty"`
+	Quantity                   int              	`json:"quantity,omitempty"`
+	Price                      *decimal.Decimal 	`json:"price,omitempty"`
+	TotalDiscount              *decimal.Decimal 	`json:"total_discount,omitempty"`
+	Title                      string           	`json:"title,omitempty"`
+	VariantTitle               string           	`json:"variant_title,omitempty"`
+	Name                       string           	`json:"name,omitempty"`
+	SKU                        string           	`json:"sku,omitempty"`
+	Vendor                     string           	`json:"vendor,omitempty"`
+	GiftCard                   bool             	`json:"gift_card,omitempty"`
+	Taxable                    bool             	`json:"taxable,omitempty"`
+	FulfillmentService         string           	`json:"fulfillment_service,omitempty"`
+	RequiresShipping           bool             	`json:"requires_shipping,omitempty"`
+	VariantInventoryManagement string           	`json:"variant_inventory_management,omitempty"`
+	PreTaxPrice                *decimal.Decimal 	`json:"pre_tax_price,omitempty"`
+	Properties                 []NoteAttribute  	`json:"properties,omitempty"`
+	ProductExists              bool             	`json:"product_exists,omitempty"`
+	FulfillableQuantity        int              	`json:"fulfillable_quantity,omitempty"`
+	Grams                      int              	`json:"grams,omitempty"`
+	FulfillmentStatus          string           	`json:"fulfillment_status,omitempty"`
+	TaxLines                   []TaxLine        	`json:"tax_lines,omitempty"`
+	OriginLocation             *Address         	`json:"origin_location,omitempty"`
+	DestinationLocation        *Address         	`json:"destination_location,omitempty"`
+	AppliedDiscount            *AppliedDiscount 	`json:"applied_discount,omitempty"`
+	DiscountAllocations	   []DiscountAllocation  `json:"discount_allocations,omitempty"`
 }
 
 type LineItemProperty struct {
@@ -196,6 +197,10 @@ type LineItemProperty struct {
 type NoteAttribute struct {
 	Name  string      `json:"name,omitempty"`
 	Value interface{} `json:"value,omitempty"`
+}
+
+type DiscountAllocation struct {
+	Amount json.Number `json:"amount"`
 }
 
 // Represents the result from the orders/X.json endpoint

--- a/order.go
+++ b/order.go
@@ -200,7 +200,7 @@ type NoteAttribute struct {
 }
 
 type DiscountAllocation struct {
-	Amount json.Number `json:"amount"`
+	Amount *decimal.Decimal `json:"amount"`
 }
 
 // Represents the result from the orders/X.json endpoint


### PR DESCRIPTION
Enables people using this repo to calculate discounts applied to line items such as through a discount code. 
As visible here: LineItems -> DiscountAllocations
https://shopify.dev/docs/admin-api/rest/reference/orders/order#show-2020-04

Have also added a method to make use of this endpoint
https://shopify.dev/docs/admin-api/rest/reference/customers/customer#account_activation_url-2020-04