### PR TITLE
Add InventoryLevel and Variants all

### DIFF
--- a/fixtures/inventory_level.json
+++ b/fixtures/inventory_level.json
@@ -1,0 +1,9 @@
+{
+  "inventory_level": {
+    "inventory_item_id": 808950810,
+    "location_id": 905684977,
+    "available": 6,
+    "updated_at": "2020-04-06T10:51:56-04:00",
+    "admin_graphql_api_id": "gid://shopify/InventoryLevel/905684977?inventory_item_id=808950810"
+  }
+}

--- a/fixtures/inventory_levels.json
+++ b/fixtures/inventory_levels.json
@@ -1,0 +1,32 @@
+{
+  "inventory_levels": [
+    {
+      "inventory_item_id": 808950810,
+      "location_id": 487838322,
+      "available": 9,
+      "updated_at": "2020-04-06T10:51:36-04:00",
+      "admin_graphql_api_id": "gid://shopify/InventoryLevel/690933842?inventory_item_id=808950810"
+    },
+    {
+      "inventory_item_id": 39072856,
+      "location_id": 487838322,
+      "available": 27,
+      "updated_at": "2020-04-06T10:51:36-04:00",
+      "admin_graphql_api_id": "gid://shopify/InventoryLevel/690933842?inventory_item_id=39072856"
+    },
+    {
+      "inventory_item_id": 808950810,
+      "location_id": 905684977,
+      "available": 1,
+      "updated_at": "2020-04-06T10:51:36-04:00",
+      "admin_graphql_api_id": "gid://shopify/InventoryLevel/905684977?inventory_item_id=808950810"
+    },
+    {
+      "inventory_item_id": 39072856,
+      "location_id": 905684977,
+      "available": 3,
+      "updated_at": "2020-04-06T10:51:36-04:00",
+      "admin_graphql_api_id": "gid://shopify/InventoryLevel/905684977?inventory_item_id=39072856"
+    }
+  ]
+}

--- a/goshopify.go
+++ b/goshopify.go
@@ -108,6 +108,7 @@ type Client struct {
 	Location                   LocationService
 	DiscountCode               DiscountCodeService
 	InventoryItem              InventoryItemService
+	InventoryLevel             InventoryLevelService
 }
 
 // A general response error that follows a similar layout to Shopify's response
@@ -277,6 +278,7 @@ func NewClient(app App, shopName, token string, opts ...Option) *Client {
 	c.Location = &LocationServiceOp{client: c}
 	c.DiscountCode = &DiscountCodeServiceOp{client: c}
 	c.InventoryItem = &InventoryItemServiceOp{client: c}
+	c.InventoryLevel = &InventoryLevelServiceOp{client: c}
 
 	// apply any options
 	for _, opt := range opts {

--- a/inventory_level.go
+++ b/inventory_level.go
@@ -1,0 +1,95 @@
+package goshopify
+
+import (
+	"fmt"
+	"time"
+)
+
+const inventoryLevelsBasePath = "inventory_levels"
+
+// InventoryLevelService is an interface for interacting with the
+// inventory items endpoints of the Shopify API
+// See https://help.shopify.com/en/api/reference/inventory/inventorylevel
+type InventoryLevelService interface {
+	List(interface{}) ([]InventoryLevel, error)
+	Adjust(interface{}) (*InventoryLevel, error)
+	Delete(int64, int64) error
+	Connect(InventoryLevel) (*InventoryLevel, error)
+	Set(InventoryLevel) (*InventoryLevel, error)
+}
+
+// InventoryLevelServiceOp is the default implementation of the InventoryLevelService interface
+type InventoryLevelServiceOp struct {
+	client *Client
+}
+
+// InventoryLevel represents a Shopify inventory level
+type InventoryLevel struct {
+	InventoryItemID   int64      `json:"inventory_item_id,omitempty"`
+	LocationID        int64      `json:"location_id,omitempty"`
+	Available         int        `json:"available,omitempty"`
+	CreatedAt         *time.Time `json:"created_at,omitempty"`
+	UpdatedAt         *time.Time `json:"updated_at,omitempty"`
+	AdminGraphqlAPIID string     `json:"admin_graphql_api_id,omitempty"`
+}
+
+// InventoryLevelResource is used for handling single level requests and responses
+type InventoryLevelResource struct {
+	InventoryLevel *InventoryLevel `json:"inventory_level"`
+}
+
+// InventoryLevelsResource is used for handling multiple item responsees
+type InventoryLevelsResource struct {
+	InventoryLevels []InventoryLevel `json:"inventory_levels"`
+}
+
+// InventoryLevelListOptions is used for get list
+type InventoryLevelListOptions struct {
+	InventoryItemIDs []int64   `url:"inventory_item_ids,omitempty,comma"`
+	LocationIDs      []int64   `url:"location_ids,omitempty,comma"`
+	Limit            int       `url:"limit,omitempty"`
+	UpdatedAtMin     time.Time `url:"updated_at_min,omitempty"`
+}
+
+// InventoryLevelAdjustOptions is used for Adjust inventory levels
+type InventoryLevelAdjustOptions struct {
+	InventoryItemID int64 `json:"inventory_item_id"`
+	LocationID      int64 `json:"location_id"`
+	Adjust          int   `json:"available_adjustment"`
+}
+
+// List inventory levels
+func (s *InventoryLevelServiceOp) List(options interface{}) ([]InventoryLevel, error) {
+	path := fmt.Sprintf("%s.json", inventoryLevelsBasePath)
+	resource := new(InventoryLevelsResource)
+	err := s.client.Get(path, resource, options)
+	return resource.InventoryLevels, err
+}
+
+// Delete an inventory level
+func (s *InventoryLevelServiceOp) Delete(itemID, locationID int64) error {
+	path := fmt.Sprintf("%s.json?inventory_item_id=%v&location_id=%v",
+		inventoryLevelsBasePath, itemID, locationID)
+	return s.client.Delete(path)
+}
+
+// Connect an inventory level
+func (s *InventoryLevelServiceOp) Connect(level InventoryLevel) (*InventoryLevel, error) {
+	return s.post(fmt.Sprintf("%s/connect.json", inventoryLevelsBasePath), level)
+}
+
+// Set an inventory level
+func (s *InventoryLevelServiceOp) Set(level InventoryLevel) (*InventoryLevel, error) {
+	return s.post(fmt.Sprintf("%s/set.json", inventoryLevelsBasePath), level)
+}
+
+// Adjust the inventory level of an inventory item at a single location
+func (s *InventoryLevelServiceOp) Adjust(options interface{}) (*InventoryLevel, error) {
+	return s.post(fmt.Sprintf("%s/adjust.json", inventoryLevelsBasePath), options)
+}
+
+func (s *InventoryLevelServiceOp) post(path string, options interface{}) (*InventoryLevel, error) {
+	resource := new(InventoryLevelResource)
+	err := s.client.Post(path, options, resource)
+	return resource.InventoryLevel, err
+}

--- a/inventory_level_test.go
+++ b/inventory_level_test.go
@@ -1,0 +1,190 @@
+package goshopify
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+)
+
+func inventoryLevelTests(t *testing.T, item *InventoryLevel) {
+	if item == nil {
+		t.Errorf("InventoryItem is nil")
+		return
+	}
+
+	expectedInt := int64(808950810)
+	if item.InventoryItemID != expectedInt {
+		t.Errorf("InventoryLevel.InventoryItemID returned %+v, expected %+v",
+			item.InventoryItemID, expectedInt)
+	}
+
+	expectedInt = int64(905684977)
+	if item.LocationID != expectedInt {
+		t.Errorf("InventoryLevel.LocationID is %+v, expected %+v",
+			item.LocationID, expectedInt)
+	}
+
+	expectedAvailable := 6
+	if item.Available != expectedAvailable {
+		t.Errorf("InventoryLevel.Available is %+v, expected %+v",
+			item.Available, expectedInt)
+	}
+}
+
+func inventoryLevelsTests(t *testing.T, levels []InventoryLevel) {
+	expectedLen := 4
+	if len(levels) != expectedLen {
+		t.Errorf("InventoryLevels list lenth is %+v, expected %+v", len(levels), expectedLen)
+	}
+}
+
+func TestInventoryLevelsList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("GET",
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/inventory_levels.json", client.pathPrefix),
+		httpmock.NewBytesResponder(200, loadFixture("inventory_levels.json")))
+
+	levels, err := client.InventoryLevel.List(nil)
+	if err != nil {
+		t.Errorf("InventoryLevels.List returned error: %v", err)
+	}
+
+	inventoryLevelsTests(t, levels)
+}
+
+func TestInventoryLevelListWithItemID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	params := map[string]string{
+		"inventory_item_ids": "1,2",
+	}
+	httpmock.RegisterResponderWithQuery(
+		"GET",
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/inventory_levels.json", client.pathPrefix),
+		params,
+		httpmock.NewBytesResponder(200, loadFixture("inventory_levels.json")),
+	)
+
+	options := InventoryLevelListOptions{
+		InventoryItemIDs: []int64{1, 2},
+	}
+
+	levels, err := client.InventoryLevel.List(options)
+	if err != nil {
+		t.Errorf("InventoryLevels.List returned error: %v", err)
+	}
+
+	inventoryLevelsTests(t, levels)
+}
+
+func TestInventoryLevelListWithLocationID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	params := map[string]string{
+		"location_ids": "1,2",
+	}
+	httpmock.RegisterResponderWithQuery(
+		"GET",
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/inventory_levels.json", client.pathPrefix),
+		params,
+		httpmock.NewBytesResponder(200, loadFixture("inventory_levels.json")),
+	)
+
+	options := InventoryLevelListOptions{
+		LocationIDs: []int64{1, 2},
+	}
+
+	levels, err := client.InventoryLevel.List(options)
+	if err != nil {
+		t.Errorf("InventoryLevels.List returned error: %v", err)
+	}
+
+	inventoryLevelsTests(t, levels)
+}
+
+func TestInventoryLevelAdjust(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("POST",
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/inventory_levels/adjust.json", client.pathPrefix),
+		httpmock.NewBytesResponder(200, loadFixture("inventory_level.json")))
+
+	option := InventoryLevelAdjustOptions{
+		InventoryItemID: 808950810,
+		LocationID:      905684977,
+		Adjust:          6,
+	}
+
+	adjItem, err := client.InventoryLevel.Adjust(option)
+	if err != nil {
+		t.Errorf("InventoryLevel.Adjust returned error: %v", err)
+	}
+
+	inventoryLevelTests(t, adjItem)
+}
+
+func TestInventoryLevelDelete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("DELETE",
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/inventory_levels.json", client.pathPrefix),
+		httpmock.NewStringResponder(200, "{}"))
+
+	err := client.InventoryLevel.Delete(1, 1)
+	if err != nil {
+		t.Errorf("InventoryLevel.Delete returned error: %v", err)
+	}
+}
+
+func TestInventoryLevelConnect(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder(
+		"POST",
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/inventory_levels/connect.json", client.pathPrefix),
+		httpmock.NewBytesResponder(200, loadFixture("inventory_level.json")),
+	)
+
+	options := InventoryLevel{
+		InventoryItemID: 1,
+		LocationID:      1,
+	}
+
+	level, err := client.InventoryLevel.Connect(options)
+	if err != nil {
+		t.Errorf("InventoryLevels.Connect returned error: %v", err)
+	}
+
+	inventoryLevelTests(t, level)
+}
+
+func TestInventoryLevelSet(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder(
+		"POST",
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/inventory_levels/set.json", client.pathPrefix),
+		httpmock.NewBytesResponder(200, loadFixture("inventory_level.json")),
+	)
+
+	options := InventoryLevel{
+		InventoryItemID: 1,
+		LocationID:      1,
+	}
+
+	level, err := client.InventoryLevel.Set(options)
+	if err != nil {
+		t.Errorf("InventoryLevels.Set returned error: %v", err)
+	}
+
+	inventoryLevelTests(t, level)
+}

--- a/order.go
+++ b/order.go
@@ -156,33 +156,38 @@ type DiscountCode struct {
 	Type   string           `json:"type,omitempty"`
 }
 
+type DiscountAllocation struct {
+	Amount *decimal.Decimal `json:"amount,omitempty"`
+}
+
 type LineItem struct {
-	ID                         int64            `json:"id,omitempty"`
-	ProductID                  int64            `json:"product_id,omitempty"`
-	VariantID                  int64            `json:"variant_id,omitempty"`
-	Quantity                   int              `json:"quantity,omitempty"`
-	Price                      *decimal.Decimal `json:"price,omitempty"`
-	TotalDiscount              *decimal.Decimal `json:"total_discount,omitempty"`
-	Title                      string           `json:"title,omitempty"`
-	VariantTitle               string           `json:"variant_title,omitempty"`
-	Name                       string           `json:"name,omitempty"`
-	SKU                        string           `json:"sku,omitempty"`
-	Vendor                     string           `json:"vendor,omitempty"`
-	GiftCard                   bool             `json:"gift_card,omitempty"`
-	Taxable                    bool             `json:"taxable,omitempty"`
-	FulfillmentService         string           `json:"fulfillment_service,omitempty"`
-	RequiresShipping           bool             `json:"requires_shipping,omitempty"`
-	VariantInventoryManagement string           `json:"variant_inventory_management,omitempty"`
-	PreTaxPrice                *decimal.Decimal `json:"pre_tax_price,omitempty"`
-	Properties                 []NoteAttribute  `json:"properties,omitempty"`
-	ProductExists              bool             `json:"product_exists,omitempty"`
-	FulfillableQuantity        int              `json:"fulfillable_quantity,omitempty"`
-	Grams                      int              `json:"grams,omitempty"`
-	FulfillmentStatus          string           `json:"fulfillment_status,omitempty"`
-	TaxLines                   []TaxLine        `json:"tax_lines,omitempty"`
-	OriginLocation             *Address         `json:"origin_location,omitempty"`
-	DestinationLocation        *Address         `json:"destination_location,omitempty"`
-	AppliedDiscount            *AppliedDiscount `json:"applied_discount,omitempty"`
+	ID                         int64                `json:"id,omitempty"`
+	ProductID                  int64                `json:"product_id,omitempty"`
+	VariantID                  int64                `json:"variant_id,omitempty"`
+	Quantity                   int                  `json:"quantity,omitempty"`
+	Price                      *decimal.Decimal     `json:"price,omitempty"`
+	TotalDiscount              *decimal.Decimal     `json:"total_discount,omitempty"`
+	Title                      string               `json:"title,omitempty"`
+	VariantTitle               string               `json:"variant_title,omitempty"`
+	Name                       string               `json:"name,omitempty"`
+	SKU                        string               `json:"sku,omitempty"`
+	Vendor                     string               `json:"vendor,omitempty"`
+	GiftCard                   bool                 `json:"gift_card,omitempty"`
+	Taxable                    bool                 `json:"taxable,omitempty"`
+	FulfillmentService         string               `json:"fulfillment_service,omitempty"`
+	RequiresShipping           bool                 `json:"requires_shipping,omitempty"`
+	VariantInventoryManagement string               `json:"variant_inventory_management,omitempty"`
+	PreTaxPrice                *decimal.Decimal     `json:"pre_tax_price,omitempty"`
+	Properties                 []NoteAttribute      `json:"properties,omitempty"`
+	ProductExists              bool                 `json:"product_exists,omitempty"`
+	FulfillableQuantity        int                  `json:"fulfillable_quantity,omitempty"`
+	Grams                      int                  `json:"grams,omitempty"`
+	FulfillmentStatus          string               `json:"fulfillment_status,omitempty"`
+	TaxLines                   []TaxLine            `json:"tax_lines,omitempty"`
+	OriginLocation             *Address             `json:"origin_location,omitempty"`
+	DestinationLocation        *Address             `json:"destination_location,omitempty"`
+	AppliedDiscount            *AppliedDiscount     `json:"applied_discount,omitempty"`
+	DiscountAllocations        []DiscountAllocation `json:"discount_allocations,omitempty"`
 }
 
 // UnmarshalJSON custom unmarsaller for LineItem required to mitigate some older orders having LineItem.Properies

--- a/variant.go
+++ b/variant.go
@@ -15,7 +15,9 @@ const variantsResourceName = "variants"
 // See https://help.shopify.com/api/reference/product_variant
 type VariantService interface {
 	List(int64, interface{}) ([]Variant, error)
+	ListAll(interface{}) ([]Variant, error)
 	Count(int64, interface{}) (int, error)
+	CountAll(interface{}) (int, error)
 	Get(int64, interface{}) (*Variant, error)
 	Create(int64, Variant) (*Variant, error)
 	Update(Variant) (*Variant, error)
@@ -81,9 +83,24 @@ func (s *VariantServiceOp) List(productID int64, options interface{}) ([]Variant
 	return resource.Variants, err
 }
 
+// ListAll get all variants (undocumented in Shopify)
+// maximum limit 250, with parameter since_id, get others variants
+func (s *VariantServiceOp) ListAll(options interface{}) ([]Variant, error) {
+	path := fmt.Sprintf("%s.json", variantsBasePath)
+	resource := new(VariantsResource)
+	err := s.client.Get(path, resource, options)
+	return resource.Variants, err
+}
+
 // Count variants
 func (s *VariantServiceOp) Count(productID int64, options interface{}) (int, error) {
 	path := fmt.Sprintf("%s/%d/variants/count.json", productsBasePath, productID)
+	return s.client.Count(path, options)
+}
+
+// CountAll variants (undocumented in Shopify)
+func (s *VariantServiceOp) CountAll(options interface{}) (int, error) {
+	path := fmt.Sprintf("%s/count.json", variantsBasePath)
 	return s.client.Count(path, options)
 }
 

--- a/variant_test.go
+++ b/variant_test.go
@@ -81,6 +81,24 @@ func TestVariantList(t *testing.T) {
 	}
 }
 
+func TestVariantListAll(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants.json", client.pathPrefix),
+		httpmock.NewStringResponder(200, `{"variants": [{"id":1},{"id":2}]}`))
+
+	variants, err := client.Variant.ListAll(nil)
+	if err != nil {
+		t.Errorf("Variant.ListAll returned error: %v", err)
+	}
+
+	expected := []Variant{{ID: 1}, {ID: 2}}
+	if !reflect.DeepEqual(variants, expected) {
+		t.Errorf("Variant.ListAll returned %+v, expected %+v", variants, expected)
+	}
+}
+
 func TestVariantCount(t *testing.T) {
 	setup()
 	defer teardown()
@@ -114,6 +132,24 @@ func TestVariantCount(t *testing.T) {
 	expected = 2
 	if cnt != expected {
 		t.Errorf("Variant.Count returned %d, expected %d", cnt, expected)
+	}
+}
+
+func TestVariantCountAll(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/variants/count.json", client.pathPrefix),
+		httpmock.NewStringResponder(200, `{"count": 3}`))
+
+	cnt, err := client.Variant.CountAll(nil)
+	if err != nil {
+		t.Errorf("Variant.CountAll returned error: %v", err)
+	}
+
+	expected := 3
+	if cnt != expected {
+		t.Errorf("Variant.CountAll returned %d, expected %d", cnt, expected)
 	}
 }
 


### PR DESCRIPTION
Added https://shopify.dev/docs/admin-api/rest/reference/inventory/inventorylevel support

And Shopify undocumented:
/admin/variant.json to get all variants
/admin/variants/count.json to count all variants