### PR TITLE
Add Order actions: Cancel, Close and Open

### DIFF
--- a/order.go
+++ b/order.go
@@ -22,6 +22,9 @@ type OrderService interface {
 	Get(int64, interface{}) (*Order, error)
 	Create(Order) (*Order, error)
 	Update(Order) (*Order, error)
+	Cancel(int64, interface{}) (*Order, error)
+	Close(int64) (*Order, error)
+	Open(int64) (*Order, error)
 
 	// MetafieldsService used for Order resource to communicate with Metafields resource
 	MetafieldsService
@@ -378,6 +381,30 @@ func (s *OrderServiceOp) Update(order Order) (*Order, error) {
 	wrappedData := OrderResource{Order: &order}
 	resource := new(OrderResource)
 	err := s.client.Put(path, wrappedData, resource)
+	return resource.Order, err
+}
+
+// Cancel order
+func (s *OrderServiceOp) Cancel(orderID int64, options interface{}) (*Order, error) {
+	path := fmt.Sprintf("%s/%d/cancel.json", ordersBasePath, orderID)
+	resource := new(OrderResource)
+	err := s.client.Post(path, options, resource)
+	return resource.Order, err
+}
+
+// Close order
+func (s *OrderServiceOp) Close(orderID int64) (*Order, error) {
+	path := fmt.Sprintf("%s/%d/close.json", ordersBasePath, orderID)
+	resource := new(OrderResource)
+	err := s.client.Post(path, nil, resource)
+	return resource.Order, err
+}
+
+// Open order
+func (s *OrderServiceOp) Open(orderID int64) (*Order, error) {
+	path := fmt.Sprintf("%s/%d/open.json", ordersBasePath, orderID)
+	resource := new(OrderResource)
+	err := s.client.Post(path, nil, resource)
 	return resource.Order, err
 }
 

--- a/order.go
+++ b/order.go
@@ -67,6 +67,17 @@ type OrderListOptions struct {
 	Order             string    `url:"order,omitempty"`
 }
 
+// A struct of all available order cancel options.
+// See: https://help.shopify.com/api/reference/order#index
+type OrderCancelOptions struct {
+	Amount   *decimal.Decimal `json:"amount,omitempty"`
+	Currency string           `json:"currency,omitempty"`
+	Restock  bool             `json:"restock,omitempty"`
+	Reason   string           `json:"reason,omitempty"`
+	Email    bool             `json:"email,omitempty"`
+	Refund   *Refund          `json:"refund,omitempty"`
+}
+
 // Order represents a Shopify order
 type Order struct {
 	ID                    int64            `json:"id,omitempty"`


### PR DESCRIPTION
As per Shopify API there are three actions on the `Order` resource that haven't been implemented in this package yet. This PR introduces these new actions as methods on the `OrderService`:

- Cancel order, with options for notes or refund amount
- Close order
- Re-open order

Ref: https://shopify.dev/docs/admin-api/rest/reference/orders/order?api[version]=2020-04#cancel-2020-04