### PR TITLE
Limit Memory Usage When Logging Req/Resp Bodies

### DIFF
--- a/goshopify_test.go
+++ b/goshopify_test.go
@@ -350,6 +350,14 @@ func TestDo(t *testing.T) {
 	}
 }
 
+func TestWithMaxBodyBytes(t *testing.T) {
+	testClient := NewClient(app, "fooshop", "abcd", WithMaxBodyBytes(128))
+	expected := int64(128)
+	if testClient.maxBodyBytes != expected {
+		t.Errorf("NewClient maxBodyBytes = %d, expected %d", testClient.maxBodyBytes, expected)
+	}
+}
+
 func TestRetry(t *testing.T) {
 	setup()
 	defer teardown()

--- a/goshopify_test.go
+++ b/goshopify_test.go
@@ -333,6 +333,11 @@ func TestDo(t *testing.T) {
 			t.Error("error creating request: ", err)
 		}
 
+		expected := defaultMaxBodyBytes
+		if client.maxBodyBytes != expected {
+			t.Errorf("NewClient maxBodyBytes = %d, expected %d", client.maxBodyBytes, expected)
+		}
+
 		err = client.Do(req, body)
 		if err != nil {
 			if e, ok := err.(*url.Error); ok {

--- a/logger_test.go
+++ b/logger_test.go
@@ -150,6 +150,14 @@ func TestDoGetHeadersDebug(t *testing.T) {
 	}
 }
 
+func TestCheckMaxBodyBytes(t *testing.T) {
+	client := NewClient(app, "fooshop", "abcd")
+	client.checkMaxBodyBytes()
+	if client.maxBodyBytes != defaultMaxBodyBytes {
+		t.Errorf("checkMaxBodyBytes failed, expected client.maxBodyBytes to be set to the the default value of %d, but was set to %d", defaultMaxBodyBytes, client.maxBodyBytes)
+	}
+}
+
 var largeReqRespBody = func() string {
 	b, err := ioutil.ReadFile("./fixtures/orders.json")
 	if err != nil {

--- a/options.go
+++ b/options.go
@@ -28,3 +28,9 @@ func WithLogger(logger LeveledLoggerInterface) Option {
 		c.log = logger
 	}
 }
+
+func WithMaxBodyBytes(maxBodyBytes int64) Option {
+	return func(c *Client) {
+		c.maxBodyBytes = maxBodyBytes
+	}
+}


### PR DESCRIPTION
Swapped the `ioutil.ReadAll()` call here for a `LimitReader` to cap memory usage per logged body.
Also added a bit of extra test coverage to ensure that `logBody` is resetting the Reader after logging it, as well as added coverage with a large request/response body.