### PR TITLE
Allow null variant compare_at_price

### DIFF
--- a/variant.go
+++ b/variant.go
@@ -33,34 +33,38 @@ type VariantServiceOp struct {
 
 // Variant represents a Shopify variant
 type Variant struct {
-	ID                   int64            `json:"id,omitempty"`
-	ProductID            int64            `json:"product_id,omitempty"`
-	Title                string           `json:"title,omitempty"`
-	Sku                  string           `json:"sku,omitempty"`
-	Position             int              `json:"position,omitempty"`
-	Grams                int              `json:"grams,omitempty"`
-	InventoryPolicy      string           `json:"inventory_policy,omitempty"`
-	Price                *decimal.Decimal `json:"price,omitempty"`
-	CompareAtPrice       *decimal.Decimal `json:"compare_at_price,omitempty"`
-	FulfillmentService   string           `json:"fulfillment_service,omitempty"`
-	InventoryManagement  string           `json:"inventory_management,omitempty"`
-	InventoryItemId      int64            `json:"inventory_item_id,omitempty"`
-	Option1              string           `json:"option1,omitempty"`
-	Option2              string           `json:"option2,omitempty"`
-	Option3              string           `json:"option3,omitempty"`
-	CreatedAt            *time.Time       `json:"created_at,omitempty"`
-	UpdatedAt            *time.Time       `json:"updated_at,omitempty"`
-	Taxable              bool             `json:"taxable,omitempty"`
-	TaxCode              string           `json:"tax_code,omitempty"`
-	Barcode              string           `json:"barcode,omitempty"`
-	ImageID              int64            `json:"image_id,omitempty"`
-	InventoryQuantity    int              `json:"inventory_quantity,omitempty"`
-	Weight               *decimal.Decimal `json:"weight,omitempty"`
-	WeightUnit           string           `json:"weight_unit,omitempty"`
-	OldInventoryQuantity int              `json:"old_inventory_quantity,omitempty"`
-	RequireShipping      bool             `json:"requires_shipping,omitempty"`
-	AdminGraphqlAPIID    string           `json:"admin_graphql_api_id,omitempty"`
-	Metafields           []Metafield      `json:"metafields,omitempty"`
+	ID              int64            `json:"id,omitempty"`
+	ProductID       int64            `json:"product_id,omitempty"`
+	Title           string           `json:"title,omitempty"`
+	Sku             string           `json:"sku,omitempty"`
+	Position        int              `json:"position,omitempty"`
+	Grams           int              `json:"grams,omitempty"`
+	InventoryPolicy string           `json:"inventory_policy,omitempty"`
+	Price           *decimal.Decimal `json:"price,omitempty"`
+	// To update CompareAtPrice to null ensure it points to a NullDecimal with Valid=false
+	// To ignore the CompareAtPrice during an update ensure the pointer is nil
+	// To update CompareAtPrice to any other value ensure it points to a NullDecimal with Valid=true
+	// Note JSON responses that are null or omitted always result in a null pointer
+	CompareAtPrice       *decimal.NullDecimal `json:"compare_at_price,omitempty"`
+	FulfillmentService   string               `json:"fulfillment_service,omitempty"`
+	InventoryManagement  string               `json:"inventory_management,omitempty"`
+	InventoryItemId      int64                `json:"inventory_item_id,omitempty"`
+	Option1              string               `json:"option1,omitempty"`
+	Option2              string               `json:"option2,omitempty"`
+	Option3              string               `json:"option3,omitempty"`
+	CreatedAt            *time.Time           `json:"created_at,omitempty"`
+	UpdatedAt            *time.Time           `json:"updated_at,omitempty"`
+	Taxable              bool                 `json:"taxable,omitempty"`
+	TaxCode              string               `json:"tax_code,omitempty"`
+	Barcode              string               `json:"barcode,omitempty"`
+	ImageID              int64                `json:"image_id,omitempty"`
+	InventoryQuantity    int                  `json:"inventory_quantity,omitempty"`
+	Weight               *decimal.Decimal     `json:"weight,omitempty"`
+	WeightUnit           string               `json:"weight_unit,omitempty"`
+	OldInventoryQuantity int                  `json:"old_inventory_quantity,omitempty"`
+	RequireShipping      bool                 `json:"requires_shipping,omitempty"`
+	AdminGraphqlAPIID    string               `json:"admin_graphql_api_id,omitempty"`
+	Metafields           []Metafield          `json:"metafields,omitempty"`
 }
 
 // VariantResource represents the result from the variants/X.json endpoint


### PR DESCRIPTION
`compare_at_price` is a nullable field in Shopify.  This change allows setting the `compare_at_price` to be `null` during a product variant update.  

During a product variant update the field can be set 3 different ways:
- To update compare_at_price to null ensure it points to a NullDecimal with Valid=false
- To ignore the compare_at_price during an update ensure the pointer is nil
- To update compare_at_price to any other value ensure it points to a NullDecimal with Valid=true
