### PR TITLE
Add ProductListing support for Sales Channel Apps

### DIFF
--- a/fixtures/product_listing.json
+++ b/fixtures/product_listing.json
@@ -1,0 +1,59 @@
+{
+    "product_listing": {
+      "product_id": 921728736,
+      "created_at": "2020-07-09T13:45:19-04:00",
+      "updated_at": "2020-07-09T13:45:19-04:00",
+      "body_html": "<p>The iPod Touch has the iPhone's multi-touch interface, with a physical home button off the touch screen. The home screen has a list of buttons for the available applications.</p>",
+      "handle": "ipod-touch",
+      "product_type": "Cult Products",
+      "title": "IPod Touch 8GB",
+      "vendor": "Apple",
+      "available": true,
+      "tags": "",
+      "published_at": "2017-08-31T20:00:00-04:00",
+      "variants": [
+        {
+          "id": 447654529,
+          "title": "Black",
+          "option_values": [
+            {
+              "option_id": 891236591,
+              "name": "Title",
+              "value": "Black"
+            }
+          ],
+          "price": "199.00",
+          "formatted_price": "$199.00",
+          "compare_at_price": null,
+          "grams": 567,
+          "requires_shipping": true,
+          "sku": "IPOD2009BLACK",
+          "barcode": "1234_black",
+          "taxable": true,
+          "position": 1,
+          "available": true,
+          "inventory_policy": "continue",
+          "inventory_quantity": 13,
+          "inventory_management": "shipwire-app",
+          "fulfillment_service": "shipwire-app",
+          "weight": 1.25,
+          "weight_unit": "lb",
+          "image_id": null,
+          "created_at": "2020-07-09T13:45:19-04:00",
+          "updated_at": "2020-07-09T13:45:19-04:00"
+        }
+      ],
+      "images": [],
+      "options": [
+        {
+          "id": 891236591,
+          "name": "Title",
+          "product_id": 921728736,
+          "position": 1,
+          "values": [
+            "Black"
+          ]
+        }
+      ]
+    }
+  }

--- a/goshopify.go
+++ b/goshopify.go
@@ -87,7 +87,7 @@ type Client struct {
 	Customer                   CustomerService
 	CustomerAddress            CustomerAddressService
 	Order                      OrderService
-	Fulfillment		   FulfillmentService
+	Fulfillment                FulfillmentService
 	DraftOrder                 DraftOrderService
 	Shop                       ShopService
 	Webhook                    WebhookService
@@ -111,6 +111,7 @@ type Client struct {
 	PriceRule                  PriceRuleService
 	InventoryItem              InventoryItemService
 	ShippingZone               ShippingZoneService
+	ProductListing             ProductListingService
 }
 
 // A general response error that follows a similar layout to Shopify's response
@@ -283,6 +284,7 @@ func NewClient(app App, shopName, token string, opts ...Option) *Client {
 	c.PriceRule = &PriceRuleServiceOp{client: c}
 	c.InventoryItem = &InventoryItemServiceOp{client: c}
 	c.ShippingZone = &ShippingZoneServiceOp{client: c}
+	c.ProductListing = &ProductListingServiceOp{client: c}
 
 	// apply any options
 	for _, opt := range opts {

--- a/product_listing.go
+++ b/product_listing.go
@@ -60,11 +60,6 @@ type ProductListingIDsResource struct {
 	ProductIDs []int64 `json:"product_ids"`
 }
 
-// ProductID represents a products unique Shopify identifier
-type ProductID struct {
-	ProductID int64 `json:"product_id"`
-}
-
 // Resource which create product_listing endpoint expects in request body
 // e.g.
 // PUT /admin/api/2020-07/product_listings/921728736.json
@@ -75,7 +70,7 @@ type ProductID struct {
 // }
 type ProductListingPublishResource struct {
 	ProductListing struct {
-		ProductID
+		ProductID int64 `json:"product_id"`
 	} `json:"product_listing"`
 }
 
@@ -136,7 +131,7 @@ func (s *ProductListingServiceOp) GetProductIDs(options interface{}) ([]int64, e
 func (s *ProductListingServiceOp) Publish(productID int64) (*ProductListing, error) {
 	path := fmt.Sprintf("%s/%v.json", productListingBasePath, productID)
 	wrappedData := new(ProductListingPublishResource)
-	wrappedData.ProductListing.ProductID.ProductID = productID
+	wrappedData.ProductListing.ProductID = productID
 	resource := new(ProductListingResource)
 	err := s.client.Put(path, wrappedData, resource)
 	return resource.ProductListing, err

--- a/product_listing.go
+++ b/product_listing.go
@@ -17,7 +17,7 @@ type ProductListingService interface {
 	ListWithPagination(interface{}) ([]ProductListing, *Pagination, error)
 	Count(interface{}) (int, error)
 	Get(int64, interface{}) (*ProductListing, error)
-	GetProductIDs(interface{}) ([]ProductID, error)
+	GetProductIDs(interface{}) ([]int64, error)
 	Publish(int64) (*ProductListing, error)
 	Delete(int64) error
 }
@@ -57,7 +57,7 @@ type ProductsListingsResource struct {
 
 // Represents the result from the product_listings/product_ids.json endpoint
 type ProductListingIDsResource struct {
-	ProductIDs []ProductID `json:"product_ids"`
+	ProductIDs []int64 `json:"product_ids"`
 }
 
 // ProductID represents a products unique Shopify identifier
@@ -125,7 +125,7 @@ func (s *ProductListingServiceOp) Get(productID int64, options interface{}) (*Pr
 }
 
 // GetProductIDs lists all product IDs that are published to your sales channel
-func (s *ProductListingServiceOp) GetProductIDs(options interface{}) ([]ProductID, error) {
+func (s *ProductListingServiceOp) GetProductIDs(options interface{}) ([]int64, error) {
 	path := fmt.Sprintf("%s/product_ids.json", productListingBasePath)
 	resource := new(ProductListingIDsResource)
 	err := s.client.Get(path, resource, options)

--- a/product_listing.go
+++ b/product_listing.go
@@ -1,0 +1,149 @@
+package goshopify
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const productListingBasePath = "product_listings"
+const productsListingResourceName = "product_listings"
+
+// linkRegex is used to extract pagination links from product search results.
+//var linkRegex = regexp.MustCompile(`^ *<([^>]+)>; rel="(previous|next)" *$`)
+
+// ProductListingService is an interface for interfacing with the product listing endpoints
+// of the Shopify API.
+// See: https://help.shopify.com/api/reference/product_listings
+type ProductListingService interface {
+	List(interface{}) ([]ProductListing, error)
+	ListWithPagination(interface{}) ([]ProductListing, *Pagination, error)
+	Count(interface{}) (int, error)
+	Get(int64, interface{}) (*ProductListing, error)
+	GetProductIDs(interface{}) ([]int64, error)
+	//GetProductIDsWithPagination????() ([]int64, *Pagination, error)
+	Publish(int64) (*ProductListing, error)
+	Delete(int64) error
+}
+
+// ProductListingServiceOp handles communication with the product related methods of
+// the Shopify API.
+type ProductListingServiceOp struct {
+	client *Client
+}
+
+// ProductListing represents a Shopify product published to your sales channel app
+type ProductListing struct {
+	ID          int64           `json:"product_id,omitempty"`
+	Title       string          `json:"title,omitempty"`
+	BodyHTML    string          `json:"body_html,omitempty"`
+	Vendor      string          `json:"vendor,omitempty"`
+	ProductType string          `json:"product_type,omitempty"`
+	Handle      string          `json:"handle,omitempty"`
+	CreatedAt   *time.Time      `json:"created_at,omitempty"`
+	UpdatedAt   *time.Time      `json:"updated_at,omitempty"`
+	PublishedAt *time.Time      `json:"published_at,omitempty"`
+	Tags        string          `json:"tags,omitempty"`
+	Options     []ProductOption `json:"options,omitempty"`
+	Variants    []Variant       `json:"variants,omitempty"`
+	Images      []Image         `json:"images,omitempty"`
+}
+
+// Represents the result from the product_listings/X.json endpoint
+type ProductListingResource struct {
+	ProductListing *ProductListing `json:"product_listing"`
+}
+
+// Represents the result from the product_listings.json endpoint
+type ProductsListingsResource struct {
+	ProductListings []ProductListing `json:"product_listings"`
+}
+
+// Represents the result from the product_listings/product_ids.json endpoint
+type ProductListingIDsResource struct {
+	ProductIDs []int64 `json:"product_ids"`
+}
+
+// Resource which create product_listing endpoint expects in request body
+// e.g.
+// PUT /admin/api/2020-07/product_listings/921728736.json
+// {
+//   "product_listing": {
+//     "product_id": 921728736
+//   }
+// }
+type ProductListingPublishResource struct {
+	ProductListing struct {
+		ProductID int64 `json:"product_id"`
+	} `json:"product_listing"`
+}
+
+// List products
+func (s *ProductListingServiceOp) List(options interface{}) ([]ProductListing, error) {
+	products, _, err := s.ListWithPagination(options)
+	if err != nil {
+		return nil, err
+	}
+	return products, nil
+}
+
+// ListWithPagination lists products and return pagination to retrieve next/previous results.
+func (s *ProductListingServiceOp) ListWithPagination(options interface{}) ([]ProductListing, *Pagination, error) {
+	path := fmt.Sprintf("%s.json", productListingBasePath)
+	resource := new(ProductsListingsResource)
+	headers := http.Header{}
+
+	headers, err := s.client.createAndDoGetHeaders("GET", path, nil, options, resource)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Extract pagination info from header
+	linkHeader := headers.Get("Link")
+
+	pagination, err := extractPagination(linkHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return resource.ProductListings, pagination, nil
+}
+
+// Count products listings published to your sales channel app
+func (s *ProductListingServiceOp) Count(options interface{}) (int, error) {
+	path := fmt.Sprintf("%s/count.json", productListingBasePath)
+	return s.client.Count(path, options)
+}
+
+// Get individual product_listing by product ID
+func (s *ProductListingServiceOp) Get(productID int64, options interface{}) (*ProductListing, error) {
+	path := fmt.Sprintf("%s/%d.json", productListingBasePath, productID)
+	fmt.Println(path)
+	resource := new(ProductListingResource)
+	err := s.client.Get(path, resource, options)
+	return resource.ProductListing, err
+}
+
+// GetProductIDs lists all product IDs that are published to your sales channel
+func (s *ProductListingServiceOp) GetProductIDs(options interface{}) ([]int64, error) {
+	path := fmt.Sprintf("%s/product_ids.json", productListingBasePath)
+	resource := new(ProductListingIDsResource)
+	err := s.client.Get(path, resource, options)
+	return resource.ProductIDs, err
+}
+
+// Publish an existing product listing to your sales channel app
+func (s *ProductListingServiceOp) Publish(productID int64) (*ProductListing, error) {
+	path := fmt.Sprintf("%s/%v.json", productListingBasePath, productID)
+	wrappedData := new(ProductListingPublishResource)
+	wrappedData.ProductListing.ProductID = productID
+	resource := new(ProductListingResource)
+	err := s.client.Put(path, wrappedData, resource)
+	fmt.Printf("%+v\n\n\n", resource)
+	return resource.ProductListing, err
+}
+
+// Delete unpublishes an existing product from your sales channel app.
+func (s *ProductListingServiceOp) Delete(productID int64) error {
+	return s.client.Delete(fmt.Sprintf("%s/%d.json", productsBasePath, productID))
+}

--- a/product_listing.go
+++ b/product_listing.go
@@ -118,7 +118,6 @@ func (s *ProductListingServiceOp) Count(options interface{}) (int, error) {
 // Get individual product_listing by product ID
 func (s *ProductListingServiceOp) Get(productID int64, options interface{}) (*ProductListing, error) {
 	path := fmt.Sprintf("%s/%d.json", productListingBasePath, productID)
-	fmt.Println(path)
 	resource := new(ProductListingResource)
 	err := s.client.Get(path, resource, options)
 	return resource.ProductListing, err
@@ -139,11 +138,10 @@ func (s *ProductListingServiceOp) Publish(productID int64) (*ProductListing, err
 	wrappedData.ProductListing.ProductID = productID
 	resource := new(ProductListingResource)
 	err := s.client.Put(path, wrappedData, resource)
-	fmt.Printf("%+v\n\n\n", resource)
 	return resource.ProductListing, err
 }
 
 // Delete unpublishes an existing product from your sales channel app.
 func (s *ProductListingServiceOp) Delete(productID int64) error {
-	return s.client.Delete(fmt.Sprintf("%s/%d.json", productsBasePath, productID))
+	return s.client.Delete(fmt.Sprintf("%s/%d.json", productListingBasePath, productID))
 }

--- a/product_listing_test.go
+++ b/product_listing_test.go
@@ -274,7 +274,7 @@ func TestProductListingDelete(t *testing.T) {
 	setup()
 	defer teardown()
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1.json", client.pathPrefix),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/product_listings/1.json", client.pathPrefix),
 		httpmock.NewStringResponder(200, "{}"))
 
 	err := client.ProductListing.Delete(1)

--- a/product_listing_test.go
+++ b/product_listing_test.go
@@ -1,0 +1,284 @@
+package goshopify
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/jarcoal/httpmock"
+)
+
+func productListingTests(t *testing.T, product ProductListing) {
+	// Check that ID is assigned to the returned product
+	var expectedInt int64 = 921728736
+	if product.ID != expectedInt {
+		t.Errorf("Product.ID returned %+v, expected %+v", product.ID, expectedInt)
+	}
+}
+
+func TestProductListingList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/product_listings.json", client.pathPrefix),
+		httpmock.NewStringResponder(200, `{"product_listings": [{"product_id":1},{"product_id":2}]}`))
+
+	products, err := client.ProductListing.List(nil)
+	if err != nil {
+		t.Errorf("ProductListing.List returned error: %v", err)
+	}
+
+	expected := []ProductListing{{ID: 1}, {ID: 2}}
+	if !reflect.DeepEqual(products, expected) {
+		t.Errorf("ProductListing.List returned %+v, expected %+v", products, expected)
+	}
+}
+
+func TestProductListingListError(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/product_listings.json", client.pathPrefix),
+		httpmock.NewStringResponder(500, ""))
+
+	expectedErrMessage := "Unknown Error"
+
+	products, err := client.ProductListing.List(nil)
+	if products != nil {
+		t.Errorf("ProductListing.List returned products, expected nil: %v", err)
+	}
+
+	if err == nil || err.Error() != expectedErrMessage {
+		t.Errorf("ProductListing.List err returned %+v, expected %+v", err, expectedErrMessage)
+	}
+}
+
+func TestProductListingListWithPagination(t *testing.T) {
+	setup()
+	defer teardown()
+
+	listURL := fmt.Sprintf("https://fooshop.myshopify.com/%s/product_listings.json", client.pathPrefix)
+
+	// The strconv.Atoi error changed in go 1.8, 1.7 is still being tested/supported.
+	limitConversionErrorMessage := `strconv.Atoi: parsing "invalid": invalid syntax`
+	if runtime.Version()[2:5] == "1.7" {
+		limitConversionErrorMessage = `strconv.ParseInt: parsing "invalid": invalid syntax`
+	}
+
+	cases := []struct {
+		body               string
+		linkHeader         string
+		expectedProducts   []ProductListing
+		expectedPagination *Pagination
+		expectedErr        error
+	}{
+		// Expect empty pagination when there is no link header
+		{
+			`{"product_listings": [{"product_id":1},{"product_id":2}]}`,
+			"",
+			[]ProductListing{{ID: 1}, {ID: 2}},
+			new(Pagination),
+			nil,
+		},
+		// Invalid link header responses
+		{
+			"{}",
+			"invalid link",
+			[]ProductListing(nil),
+			nil,
+			ResponseDecodingError{Message: "could not extract pagination link header"},
+		},
+		{
+			"{}",
+			`<:invalid.url>; rel="next"`,
+			[]ProductListing(nil),
+			nil,
+			ResponseDecodingError{Message: "pagination does not contain a valid URL"},
+		},
+		{
+			"{}",
+			`<http://valid.url?%invalid_query>; rel="next"`,
+			[]ProductListing(nil),
+			nil,
+			errors.New(`invalid URL escape "%in"`),
+		},
+		{
+			"{}",
+			`<http://valid.url>; rel="next"`,
+			[]ProductListing(nil),
+			nil,
+			ResponseDecodingError{Message: "page_info is missing"},
+		},
+		{
+			"{}",
+			`<http://valid.url?page_info=foo&limit=invalid>; rel="next"`,
+			[]ProductListing(nil),
+			nil,
+			errors.New(limitConversionErrorMessage),
+		},
+		// Valid link header responses
+		{
+			`{"product_listings": [{"product_id":1}]}`,
+			`<http://valid.url?page_info=foo&limit=2>; rel="next"`,
+			[]ProductListing{{ID: 1}},
+			&Pagination{
+				NextPageOptions: &ListOptions{PageInfo: "foo", Limit: 2},
+			},
+			nil,
+		},
+		{
+			`{"product_listings": [{"product_id":2}]}`,
+			`<http://valid.url?page_info=foo>; rel="next", <http://valid.url?page_info=bar>; rel="previous"`,
+			[]ProductListing{{ID: 2}},
+			&Pagination{
+				NextPageOptions:     &ListOptions{PageInfo: "foo"},
+				PreviousPageOptions: &ListOptions{PageInfo: "bar"},
+			},
+			nil,
+		},
+	}
+	for i, c := range cases {
+		response := &http.Response{
+			StatusCode: 200,
+			Body:       httpmock.NewRespBodyFromString(c.body),
+			Header: http.Header{
+				"Link": {c.linkHeader},
+			},
+		}
+
+		httpmock.RegisterResponder("GET", listURL, httpmock.ResponderFromResponse(response))
+
+		products, pagination, err := client.ProductListing.ListWithPagination(nil)
+		if !reflect.DeepEqual(products, c.expectedProducts) {
+			t.Errorf("test %d ProductListing.ListWithPagination products returned %+v, expected %+v", i, products, c.expectedProducts)
+		}
+
+		if !reflect.DeepEqual(pagination, c.expectedPagination) {
+			t.Errorf(
+				"test %d ProductListing.ListWithPagination pagination returned %+v, expected %+v",
+				i,
+				pagination,
+				c.expectedPagination,
+			)
+		}
+
+		if (c.expectedErr != nil || err != nil) && err.Error() != c.expectedErr.Error() {
+			t.Errorf(
+				"test %d ProductListing.ListWithPagination err returned %+v, expected %+v",
+				i,
+				err,
+				c.expectedErr,
+			)
+		}
+	}
+}
+
+func TestProductListingsCount(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/product_listings/count.json", client.pathPrefix),
+		httpmock.NewStringResponder(200, `{"count": 3}`))
+
+	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
+	httpmock.RegisterResponderWithQuery(
+		"GET",
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/product_listings/count.json", client.pathPrefix),
+		params,
+		httpmock.NewStringResponder(200, `{"count": 2}`))
+
+	cnt, err := client.ProductListing.Count(nil)
+	if err != nil {
+		t.Errorf("Product.Count returned error: %v", err)
+	}
+
+	expected := 3
+	if cnt != expected {
+		t.Errorf("Product.Count returned %d, expected %d", cnt, expected)
+	}
+
+	date := time.Date(2016, time.January, 1, 0, 0, 0, 0, time.UTC)
+	cnt, err = client.ProductListing.Count(CountOptions{CreatedAtMin: date})
+	if err != nil {
+		t.Errorf("Product.Count returned error: %v", err)
+	}
+
+	expected = 2
+	if cnt != expected {
+		t.Errorf("Product.Count returned %d, expected %d", cnt, expected)
+	}
+}
+
+func TestProductListingGet(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/product_listings/1.json", client.pathPrefix),
+		httpmock.NewStringResponder(200, `{"product_listing": {"product_id":1}}`))
+
+	product, err := client.ProductListing.Get(1, nil)
+	if err != nil {
+		t.Errorf("ProductListing.Get returned error: %v", err)
+	}
+
+	expected := &ProductListing{ID: 1}
+	if !reflect.DeepEqual(product, expected) {
+		t.Errorf("ProductListing.Get returned %+v, expected %+v", product, expected)
+	}
+}
+
+func TestProductListingGetProductIDs(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/product_listings/product_ids.json", client.pathPrefix),
+		httpmock.NewStringResponder(200, `{"product_ids": [1,2,3]}`))
+
+	productIDs, err := client.ProductListing.GetProductIDs(nil)
+	if err != nil {
+		t.Errorf("ProductListing.Get returned error: %v", err)
+	}
+
+	expected := []int64{1, 2, 3}
+	if !reflect.DeepEqual(productIDs, expected) {
+		t.Errorf("ProductListing.Get returned %+v, expected %+v", productIDs, expected)
+	}
+}
+
+func TestProductListingPublish(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/product_listings/921728736.json", client.pathPrefix),
+		httpmock.NewBytesResponder(200, loadFixture("product_listing.json")))
+
+	product := Product{
+		ID:          921728736,
+		ProductType: "Cult Products",
+	}
+
+	returnedProduct, err := client.ProductListing.Publish(product.ID)
+	fmt.Printf("%+v", returnedProduct)
+	if err != nil {
+		t.Errorf("ProductListing.Publish returned error: %v", err)
+	}
+
+	productListingTests(t, *returnedProduct)
+}
+
+func TestProductListingDelete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/products/1.json", client.pathPrefix),
+		httpmock.NewStringResponder(200, "{}"))
+
+	err := client.ProductListing.Delete(1)
+	if err != nil {
+		t.Errorf("ProductListing.Delete returned error: %v", err)
+	}
+}


### PR DESCRIPTION
I have added support for the Product Listing endpoint which I am using for developing a sales channel app. The endpoint is used to read, create and delete products that are shared with the sales channel app. 

Shopify documentation:
https://shopify.dev/docs/admin-api/rest/reference/sales-channels/productlisting