### PR TITLE
Fix error unmarshaling when key value is string

### DIFF
--- a/goshopify.go
+++ b/goshopify.go
@@ -509,9 +509,10 @@ func CheckResponseError(r *http.Response) error {
 		// A map, parse each error for each key in the map.
 		// json always serializes into map[string]interface{} for objects
 		for k, v := range shopifyError.Errors.(map[string]interface{}) {
+			switch reflect.TypeOf(v).Kind() {
 			// Check to make sure the interface is a slice
 			// json always serializes JSON arrays into []interface{}
-			if reflect.TypeOf(v).Kind() == reflect.Slice {
+			case reflect.Slice:
 				for _, elem := range v.([]interface{}) {
 					// If the primary message of the response error is not set, use
 					// any message.
@@ -521,6 +522,13 @@ func CheckResponseError(r *http.Response) error {
 					topicAndElem := fmt.Sprintf("%v: %v", k, elem)
 					responseError.Errors = append(responseError.Errors, topicAndElem)
 				}
+			case reflect.String:
+				elem := v.(string)
+				if responseError.Message == "" {
+					responseError.Message = fmt.Sprintf("%v: %v", k, elem)
+				}
+				topicAndElem := fmt.Sprintf("%v: %v", k, elem)
+				responseError.Errors = append(responseError.Errors, topicAndElem)
 			}
 		}
 	}

--- a/goshopify_test.go
+++ b/goshopify_test.go
@@ -739,6 +739,10 @@ func TestCheckResponseError(t *testing.T) {
 			ResponseError{Status: 400, Message: "order: order is wrong", Errors: []string{"order: order is wrong"}},
 		},
 		{
+			httpmock.NewStringResponse(400, `{"errors": { "collection_id": "collection_id is wrong" }}`),
+			ResponseError{Status: 400, Message: "collection_id: collection_id is wrong", Errors: []string{"collection_id: collection_id is wrong"}},
+		},
+		{
 			httpmock.NewStringResponse(400, `{error:bad request}`),
 			errors.New("invalid character 'e' looking for beginning of object key string"),
 		},


### PR DESCRIPTION
I discovered this Shopify request:

```
GET: https://redacted.myshopify.com/admin/api/2020-10/products.json?collection_id=redacted&limit=250&page_info=redacted
```

Returns this response:

```
{"errors":{"collection_id":"collection_id cannot be passed when page_info is present. See https:\/\/help.shopify.com\/api\/guides\/paginated-rest-results for more information."}}
```

Which was not covered by the client lib.