### PR TITLE
Add GetAuthorizeUrl endpoint

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -17,7 +17,7 @@ const shopifyChecksumHeader = "X-Shopify-Hmac-Sha256"
 
 var accessTokenRelPath = "admin/oauth/access_token"
 
-// Returns a Shopify oauth authorization url for the given shopname and state.
+// Deprecated: Returns a Shopify oauth authorization url for the given shopName and state.
 //
 // State is a unique value that can be used to check the authenticity during a
 // callback from Shopify.
@@ -31,6 +31,25 @@ func (app App) AuthorizeUrl(shopName string, state string) string {
 	query.Set("state", state)
 	shopUrl.RawQuery = query.Encode()
 	return shopUrl.String()
+}
+
+// GetAuthorizeUrl returns a Shopify oauth authorization url for the given shopName and state.
+// State is a unique value that can be used to check the authenticity during a
+// callback from Shopify.
+func (app App) GetAuthorizeUrl(shopName string, state string) (string, error) {
+	shopUrl, err := url.Parse(ShopBaseUrl(shopName))
+	if err != nil {
+		return "", err
+	}
+
+	shopUrl.Path = "/admin/oauth/authorize"
+	query := shopUrl.Query()
+	query.Set("client_id", app.ApiKey)
+	query.Set("redirect_uri", app.RedirectUrl)
+	query.Set("scope", app.Scope)
+	query.Set("state", state)
+	shopUrl.RawQuery = query.Encode()
+	return shopUrl.String(), nil
 }
 
 func (app App) GetAccessToken(shopName string, code string) (string, error) {

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -32,6 +32,36 @@ func TestAppAuthorizeUrl(t *testing.T) {
 	}
 }
 
+func TestAppGetAuthorizeUrl(t *testing.T) {
+	setup()
+	defer teardown()
+
+	cases := []struct {
+		shopName      string
+		nonce         string
+		expected      string
+		expectedError string
+	}{
+		{"fooshop", "thenonce", "https://fooshop.myshopify.com/admin/oauth/authorize?client_id=apikey&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&scope=read_products&state=thenonce", ""},
+		{"foo shop", "thenonce", "", (&url.Error{
+			Op:  "parse",
+			URL: "https://foo shop.myshopify.com",
+			Err: url.InvalidHostError(" "),
+		}).Error()},
+	}
+
+	for _, c := range cases {
+		actual, err := app.GetAuthorizeUrl(c.shopName, c.nonce)
+		if actual != c.expected {
+			t.Errorf("App.GetAuthorizeUrl(): expected %s, actual %s", c.expected, actual)
+		}
+		if c.expectedError != "" && err.Error() != c.expectedError ||
+			c.expectedError == "" && err != nil {
+			t.Errorf("App.GetAuthorizeUrl(): expected error %s, actual error %s", c.expectedError, err)
+		}
+	}
+}
+
 func TestAppGetAccessToken(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
The AuthorizeUrl endpoint does not handle parsing errors.  To address this issue a new endpoint was created called GetAuthorizeUrl which has 2 return values:
* string - authorize URL
* error - any errors encountered

This new endpoint provides a safe call to retrieve the authorize url.  Also marked the AuthorizeUrl as deprecated.  