### PR TITLE
Add discount_allocations field to order's line_item

### DIFF
--- a/fixtures/orderlineitems/valid.json
+++ b/fixtures/orderlineitems/valid.json
@@ -84,5 +84,20 @@
       "value": "0.05",
       "value_type": "percent",
       "amount": "25.00"
-    }
+    },
+    "discount_allocations": [
+        {
+          "amount": "5.5",
+          "amount_set": {
+            "shop_money": {
+              "amount": "5.5",
+              "currency_code": "EUR"
+            },
+            "presentment_money": {
+              "amount": "5.5",
+              "currency_code": "EUR"
+            }
+          }
+        }
+    ]
 }

--- a/order.go
+++ b/order.go
@@ -171,32 +171,49 @@ type DiscountCode struct {
 }
 
 type LineItem struct {
-	ID                         int64            `json:"id,omitempty"`
-	ProductID                  int64            `json:"product_id,omitempty"`
-	VariantID                  int64            `json:"variant_id,omitempty"`
-	Quantity                   int              `json:"quantity,omitempty"`
-	Price                      *decimal.Decimal `json:"price,omitempty"`
-	TotalDiscount              *decimal.Decimal `json:"total_discount,omitempty"`
-	Title                      string           `json:"title,omitempty"`
-	VariantTitle               string           `json:"variant_title,omitempty"`
-	Name                       string           `json:"name,omitempty"`
-	SKU                        string           `json:"sku,omitempty"`
-	Vendor                     string           `json:"vendor,omitempty"`
-	GiftCard                   bool             `json:"gift_card,omitempty"`
-	Taxable                    bool             `json:"taxable,omitempty"`
-	FulfillmentService         string           `json:"fulfillment_service,omitempty"`
-	RequiresShipping           bool             `json:"requires_shipping,omitempty"`
-	VariantInventoryManagement string           `json:"variant_inventory_management,omitempty"`
-	PreTaxPrice                *decimal.Decimal `json:"pre_tax_price,omitempty"`
-	Properties                 []NoteAttribute  `json:"properties,omitempty"`
-	ProductExists              bool             `json:"product_exists,omitempty"`
-	FulfillableQuantity        int              `json:"fulfillable_quantity,omitempty"`
-	Grams                      int              `json:"grams,omitempty"`
-	FulfillmentStatus          string           `json:"fulfillment_status,omitempty"`
-	TaxLines                   []TaxLine        `json:"tax_lines,omitempty"`
-	OriginLocation             *Address         `json:"origin_location,omitempty"`
-	DestinationLocation        *Address         `json:"destination_location,omitempty"`
-	AppliedDiscount            *AppliedDiscount `json:"applied_discount,omitempty"`
+	ID                         int64                 `json:"id,omitempty"`
+	ProductID                  int64                 `json:"product_id,omitempty"`
+	VariantID                  int64                 `json:"variant_id,omitempty"`
+	Quantity                   int                   `json:"quantity,omitempty"`
+	Price                      *decimal.Decimal      `json:"price,omitempty"`
+	TotalDiscount              *decimal.Decimal      `json:"total_discount,omitempty"`
+	Title                      string                `json:"title,omitempty"`
+	VariantTitle               string                `json:"variant_title,omitempty"`
+	Name                       string                `json:"name,omitempty"`
+	SKU                        string                `json:"sku,omitempty"`
+	Vendor                     string                `json:"vendor,omitempty"`
+	GiftCard                   bool                  `json:"gift_card,omitempty"`
+	Taxable                    bool                  `json:"taxable,omitempty"`
+	FulfillmentService         string                `json:"fulfillment_service,omitempty"`
+	RequiresShipping           bool                  `json:"requires_shipping,omitempty"`
+	VariantInventoryManagement string                `json:"variant_inventory_management,omitempty"`
+	PreTaxPrice                *decimal.Decimal      `json:"pre_tax_price,omitempty"`
+	Properties                 []NoteAttribute       `json:"properties,omitempty"`
+	ProductExists              bool                  `json:"product_exists,omitempty"`
+	FulfillableQuantity        int                   `json:"fulfillable_quantity,omitempty"`
+	Grams                      int                   `json:"grams,omitempty"`
+	FulfillmentStatus          string                `json:"fulfillment_status,omitempty"`
+	TaxLines                   []TaxLine             `json:"tax_lines,omitempty"`
+	OriginLocation             *Address              `json:"origin_location,omitempty"`
+	DestinationLocation        *Address              `json:"destination_location,omitempty"`
+	AppliedDiscount            *AppliedDiscount      `json:"applied_discount,omitempty"`
+	DiscoundAllocations        []DiscoundAllocations `json:"discount_allocations,omitempty"`
+}
+
+type DiscoundAllocations struct {
+	Amount                   *decimal.Decimal `json:"amount,omitempty"`
+	DiscountApplicationIndex int              `json:"discount_application_index,omitempty"`
+	AmountSet                AmountSet        `json:"amount_set,omitempty"`
+}
+
+type AmountSet struct {
+	ShopMoney        AmountSetEntry `json:"shop_money,omitempty"`
+	PresentmentMoney AmountSetEntry `json:"presentment_money,omitempty"`
+}
+
+type AmountSetEntry struct {
+	Amount       *decimal.Decimal `json:"amount,omitempty"`
+	CurrencyCode string           `json:"currency_code,omitempty"`
 }
 
 // UnmarshalJSON custom unmarsaller for LineItem required to mitigate some older orders having LineItem.Properies

--- a/order.go
+++ b/order.go
@@ -197,10 +197,10 @@ type LineItem struct {
 	OriginLocation             *Address              `json:"origin_location,omitempty"`
 	DestinationLocation        *Address              `json:"destination_location,omitempty"`
 	AppliedDiscount            *AppliedDiscount      `json:"applied_discount,omitempty"`
-	DiscoundAllocations        []DiscoundAllocations `json:"discount_allocations,omitempty"`
+	DiscountAllocations        []DiscountAllocations `json:"discount_allocations,omitempty"`
 }
 
-type DiscoundAllocations struct {
+type DiscountAllocations struct {
 	Amount                   *decimal.Decimal `json:"amount,omitempty"`
 	DiscountApplicationIndex int              `json:"discount_application_index,omitempty"`
 	AmountSet                AmountSet        `json:"amount_set,omitempty"`

--- a/order_test.go
+++ b/order_test.go
@@ -1171,6 +1171,7 @@ func validLineItem() LineItem {
 	tl1Rate := decimal.New(6, -2)
 	tl2Price := decimal.New(1250, -2)
 	tl2Rate := decimal.New(5, -2)
+	discountAllocationAmount := decimal.New(55, -1)
 	return LineItem{
 		ID:                         int64(254721536),
 		ProductID:                  int64(111475476),
@@ -1257,6 +1258,21 @@ func validLineItem() LineItem {
 			Value:       "0.05",
 			ValueType:   "percent",
 			Amount:      "25.00",
+		},
+		DiscountAllocations: []DiscountAllocations{
+			{
+				Amount: &discountAllocationAmount,
+				AmountSet: AmountSet{
+					ShopMoney: AmountSetEntry{
+						Amount:       &discountAllocationAmount,
+						CurrencyCode: "EUR",
+					},
+					PresentmentMoney: AmountSetEntry{
+						Amount:       &discountAllocationAmount,
+						CurrencyCode: "EUR",
+					},
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
Adding discount_allocations in LineItem struct, regarding newest [Shopify api](https://shopify.dev/docs/admin-api/rest/reference/orders/order).