### PR TITLE
Add PriceRule prerequisite field setters

### DIFF
--- a/price_rule.go
+++ b/price_rule.go
@@ -84,6 +84,73 @@ type PriceRulesResource struct {
 	PriceRules []PriceRule `json:"price_rules"`
 }
 
+// SetPrerequisiteSubtotalRange sets or clears the subtotal range for which a cart must lie within to qualify for the price-rule
+func (pr *PriceRule) SetPrerequisiteSubtotalRange(greaterThanOrEqualTo *string) error {
+	if greaterThanOrEqualTo == nil {
+		pr.PrerequisiteSubtotalRange = nil
+	} else {
+		if !validateMoney(*greaterThanOrEqualTo) {
+			return fmt.Errorf("failed to parse value as Decimal, invalid value")
+		}
+
+		pr.PrerequisiteSubtotalRange = &prerequisiteSubtotalRange{
+			GreaterThanOrEqualTo: *greaterThanOrEqualTo,
+		}
+	}
+
+	return nil
+}
+
+// SetPrerequisiteQuantityRange sets or clears the quantity range for which a cart must lie within to qualify for the price-rule
+func (pr *PriceRule) SetPrerequisiteQuantityRange(greaterThanOrEqualTo *int) {
+	if greaterThanOrEqualTo == nil {
+		pr.PrerequisiteQuantityRange = nil
+	} else {
+		pr.PrerequisiteQuantityRange = &prerequisiteQuantityRange{
+			GreaterThanOrEqualTo: *greaterThanOrEqualTo,
+		}
+	}
+}
+
+// SetPrerequisiteShippingPriceRange sets or clears the shipping price range for which a cart must lie within to qualify for the price-rule
+func (pr *PriceRule) SetPrerequisiteShippingPriceRange(lessThanOrEqualTo *string) error {
+	if lessThanOrEqualTo == nil {
+		pr.PrerequisiteShippingPriceRange = nil
+	} else {
+		if !validateMoney(*lessThanOrEqualTo) {
+			return fmt.Errorf("failed to parse value as Decimal, invalid value")
+		}
+
+		pr.PrerequisiteShippingPriceRange = &prerequisiteShippingPriceRange{
+			LessThanOrEqualTo: *lessThanOrEqualTo,
+		}
+	}
+
+	return nil
+}
+
+// SetPrerequisiteToEntitlementQuantityRatio sets or clears the ratio between ordered items and entitled items (eg. buy X, get y free) for which a cart is eligible in the price-rule
+func (pr *PriceRule) SetPrerequisiteToEntitlementQuantityRatio(prerequisiteQuantity *int, entitledQuantity *int) {
+	if prerequisiteQuantity == nil && entitledQuantity == nil {
+		pr.PrerequisiteToEntitlementQuantityRatio = nil
+		return
+	}
+
+	var pQuant, eQuant int
+	if prerequisiteQuantity != nil {
+		pQuant = *prerequisiteQuantity
+	}
+
+	if entitledQuantity != nil {
+		eQuant = *entitledQuantity
+	}
+
+	pr.PrerequisiteToEntitlementQuantityRatio = &prerequisiteToEntitlementQuantityRatio{
+		PrerequisiteQuantity: pQuant,
+		EntitledQuantity: eQuant,
+	}
+}
+
 // Get retrieves a single price rules
 func (s *PriceRuleServiceOp) Get(priceRuleID int64) (*PriceRule, error) {
 	path := fmt.Sprintf("%s/%d.json", priceRulesBasePath, priceRuleID)
@@ -123,4 +190,9 @@ func (s *PriceRuleServiceOp) Delete(priceRuleID int64) error {
 	path := fmt.Sprintf("%s/%d.json", priceRulesBasePath, priceRuleID)
 	err := s.client.Delete(path)
 	return err
+}
+
+func validateMoney(v string) bool {
+	_, err := decimal.NewFromString(v)
+	return err == nil
 }

--- a/price_rule_test.go
+++ b/price_rule_test.go
@@ -121,3 +121,97 @@ func TestPriceRuleDelete(t *testing.T) {
 		t.Errorf("PriceRule.Delete returned error: %v", err)
 	}
 }
+
+func TestPriceRuleSetters(t *testing.T) {
+	pr := PriceRule{}
+	prereqSubtotalRange := "1.5"
+	prereqQuantityRange := 2
+	prereqShippingPrice := "5.5"
+	prereqRatioQuantity := 1
+	prereqRatioEntitledQuantity := 1
+	badMoneyString := "dog"
+
+	// Test bad money strings
+	err := pr.SetPrerequisiteSubtotalRange(&badMoneyString)
+	if err == nil {
+		t.Errorf("Expected error from setting bad string as prerequisite subtotal range: %s", badMoneyString)
+	}
+
+	err = pr.SetPrerequisiteShippingPriceRange(&badMoneyString)
+	if err == nil {
+		t.Errorf("Expected error from setting bad string as prerequisite shipping price: %s", badMoneyString)
+	}
+
+	// Test populating values
+	err = pr.SetPrerequisiteSubtotalRange(&prereqSubtotalRange)
+	if err != nil {
+		t.Errorf("Failed to set prerequisite subtotal range: %s", prereqSubtotalRange)
+	}
+
+	pr.SetPrerequisiteQuantityRange(&prereqQuantityRange)
+	err = pr.SetPrerequisiteShippingPriceRange(&prereqShippingPrice)
+	if err != nil {
+		t.Errorf("Failed to set prerequisite shipping price: %s", prereqSubtotalRange)
+	}
+
+	pr.SetPrerequisiteToEntitlementQuantityRatio(&prereqRatioQuantity, &prereqRatioEntitledQuantity)
+
+	if pr.PrerequisiteSubtotalRange.GreaterThanOrEqualTo != prereqSubtotalRange {
+		t.Errorf("Failed to set prerequisite subtotal range: %s", prereqSubtotalRange)
+	}
+
+	if pr.PrerequisiteQuantityRange.GreaterThanOrEqualTo != prereqQuantityRange {
+		t.Errorf("Failed to set prerequisite quantity range: %d", prereqQuantityRange)
+	}
+
+	if pr.PrerequisiteShippingPriceRange.LessThanOrEqualTo != prereqShippingPrice {
+		t.Errorf("Failed to set prerequisite shipping price: %s", prereqShippingPrice)
+	}
+
+	if pr.PrerequisiteToEntitlementQuantityRatio.PrerequisiteQuantity != prereqRatioQuantity {
+		t.Errorf("Failed to set prerequisite ratio quantity: %d", prereqRatioQuantity)
+	}
+
+	if pr.PrerequisiteToEntitlementQuantityRatio.EntitledQuantity != prereqRatioEntitledQuantity {
+		t.Errorf("Failed to set prerequisite ratio entitled quantity: %d", prereqRatioEntitledQuantity)
+	}
+
+	// Test clearing values by setting nil
+	err = pr.SetPrerequisiteSubtotalRange(nil)
+	if err != nil {
+		t.Errorf("Failed to set prerequisite subtotal range: %s", prereqSubtotalRange)
+	}
+
+	pr.SetPrerequisiteQuantityRange(nil)
+	err = pr.SetPrerequisiteShippingPriceRange(nil)
+	if err != nil {
+		t.Errorf("Failed to set prerequisite shipping price: %s", prereqSubtotalRange)
+	}
+
+	if pr.PrerequisiteSubtotalRange != nil {
+		t.Errorf("Failed to clear prerequisite subtotal range")
+	}
+
+	if pr.PrerequisiteQuantityRange != nil {
+		t.Errorf("Failed to clear prerequisite quantity range")
+	}
+
+	if pr.PrerequisiteShippingPriceRange != nil {
+		t.Errorf("Failed to clear prerequisite shipping price")
+	}
+
+	pr.SetPrerequisiteToEntitlementQuantityRatio(nil, &prereqRatioEntitledQuantity)
+	if pr.PrerequisiteToEntitlementQuantityRatio.PrerequisiteQuantity != 0 || pr.PrerequisiteToEntitlementQuantityRatio.EntitledQuantity != prereqRatioEntitledQuantity {
+		t.Errorf("Failed to clear prerequisite-to-entitlement-quantity-ratio prerequisite quantity")
+	}
+
+	pr.SetPrerequisiteToEntitlementQuantityRatio(&prereqRatioQuantity, nil)
+	if pr.PrerequisiteToEntitlementQuantityRatio.EntitledQuantity != 0 || pr.PrerequisiteToEntitlementQuantityRatio.PrerequisiteQuantity != prereqRatioQuantity {
+		t.Errorf("Failed to clear prerequisite-to-entitlement-quantity-ratio entitled quantity")
+	}
+
+	pr.SetPrerequisiteToEntitlementQuantityRatio(nil, nil)
+	if pr.PrerequisiteToEntitlementQuantityRatio != nil {
+		t.Errorf("Failed to clear wholly prerequisite to entitlement quantity ratio")
+	}
+}


### PR DESCRIPTION
 - prior to this change it was impossible to call the Shopify API
   specifying these fields since the type was not exposed.

Closes #143 if merged.