### PR TITLE
Change JSON field names and JSON tag

### DIFF
--- a/draft_order.go
+++ b/draft_order.go
@@ -68,7 +68,7 @@ type DraftOrder struct {
 
 // AppliedDiscount is the discount applied to the line item or the draft order object.
 type AppliedDiscount struct {
-	Title       string `json:"applied_discount,omitempty"`
+	Title       string `json:"title,omitempty"`
 	Description string `json:"description,omitempty"`
 	Value       string `json:"value,omitempty"`
 	ValueType   string `json:"value_type,omitempty"`

--- a/fixtures/orderlineitems/valid.json
+++ b/fixtures/orderlineitems/valid.json
@@ -79,7 +79,7 @@
       "zip": "R3Y 0L6"
     },
     "applied_discount": {
-      "applied_discount": "test discount",
+      "title": "test discount",
       "description": "my test discount",
       "value": "0.05",
       "value_type": "percent",


### PR DESCRIPTION
This is to report an error in the JSON tag of the "AppliedDiscount" structure described in draft_order.go.

In the "Title" field of this structure, the JSON tag is written as "applied_discount", but it should be written as "title". 

See Shopify API documentation:
https://shopify.dev/docs/admin-api/rest/reference/orders/draftorder