### PR TITLE
Remove deprecated fields

### DIFF
--- a/order.go
+++ b/order.go
@@ -130,7 +130,6 @@ type Order struct {
 	Refunds               []Refund         `json:"refunds,omitempty"`
 	UserId                int64            `json:"user_id,omitempty"`
 	OrderStatusUrl        string           `json:"order_status_url,omitempty"`
-	Gateway               string           `json:"gateway,omitempty"`
 	Confirmed             bool             `json:"confirmed,omitempty"`
 	TotalPriceUSD         *decimal.Decimal `json:"total_price_usd,omitempty"`
 	CheckoutToken         string           `json:"checkout_token,omitempty"`


### PR DESCRIPTION
The "gateway" field written in "order.json" is now deprecated and can be removed.

If you want to support older versions, you can reject this request.

See Shopify API documentation:
https://shopify.dev/docs/admin-api/rest/reference/orders/order