### PR TITLE
Support for tax_exempt in draft orders

### DIFF
--- a/draft_order.go
+++ b/draft_order.go
@@ -56,6 +56,7 @@ type DraftOrder struct {
 	AppliedDiscount *AppliedDiscount `json:"applied_discount,omitempty"`
 	TaxesIncluded   bool             `json:"taxes_included,omitempty"`
 	TotalTax        string           `json:"total_tax,omitempty"`
+	TaxExempt       *bool            `json:"tax_exempt,omitempty"`
 	TotalPrice      string           `json:"total_price,omitempty"`
 	SubtotalPrice   *decimal.Decimal `json:"subtotal_price,omitempty"`
 	CompletedAt     *time.Time       `json:"completed_at,omitempty"`


### PR DESCRIPTION
New field to allow setting `tax_exempt` on draft orders (see DraftOrder properties under https://shopify.dev/docs/admin-api/rest/reference/orders/draftorder).

From documentation:

> Whether taxes are exempt for the draft order. If set to false, then Shopify refers to the taxable field for each line_item. If a customer is applied to the draft order, then Shopify uses the customer's tax_exempt field instead.

Field is `*bool` to distinguish between setting value to false or leaving value unchanged for updates.