### PR TITLE
Adds type value to metafield struct

### DIFF
--- a/customcollection_test.go
+++ b/customcollection_test.go
@@ -238,6 +238,7 @@ func TestCustomCollectionCreateMetafield(t *testing.T) {
 		Key:       "app_key",
 		Value:     "app_value",
 		ValueType: "string",
+		Type:      "string",
 		Namespace: "affiliates",
 	}
 
@@ -261,6 +262,7 @@ func TestCustomCollectionUpdateMetafield(t *testing.T) {
 		Key:       "app_key",
 		Value:     "app_value",
 		ValueType: "string",
+		Type:      "string",
 		Namespace: "affiliates",
 	}
 

--- a/fixtures/metafield.json
+++ b/fixtures/metafield.json
@@ -5,6 +5,7 @@
     "key": "app_key",
     "value": "app_value",
     "value_type": "string",
+    "type": "string",
     "description": "some amaaazing app's value",
     "owner_id": 1,
     "created_at": "2016-01-01T00:00:00Z",

--- a/metafield.go
+++ b/metafield.go
@@ -39,17 +39,18 @@ type MetafieldServiceOp struct {
 
 // Metafield represents a Shopify metafield.
 type Metafield struct {
-	ID            int64       `json:"id,omitempty"`
-	Key           string      `json:"key,omitempty"`
-	Value         interface{} `json:"value,omitempty"`
-	ValueType     string      `json:"value_type,omitempty"`
-	Namespace     string      `json:"namespace,omitempty"`
-	Description   string      `json:"description,omitempty"`
-	OwnerId       int64       `json:"owner_id,omitempty"`
-	CreatedAt     *time.Time  `json:"created_at,omitempty"`
-	UpdatedAt     *time.Time  `json:"updated_at,omitempty"`
-	OwnerResource string      `json:"owner_resource,omitempty"`
-	AdminGraphqlAPIID string  `json:"admin_graphql_api_id,omitempty"`
+	ID                int64       `json:"id,omitempty"`
+	Key               string      `json:"key,omitempty"`
+	Value             interface{} `json:"value,omitempty"`
+	ValueType         string      `json:"value_type,omitempty"`
+	Type              string      `json:"type,omitempty"`
+	Namespace         string      `json:"namespace,omitempty"`
+	Description       string      `json:"description,omitempty"`
+	OwnerId           int64       `json:"owner_id,omitempty"`
+	CreatedAt         *time.Time  `json:"created_at,omitempty"`
+	UpdatedAt         *time.Time  `json:"updated_at,omitempty"`
+	OwnerResource     string      `json:"owner_resource,omitempty"`
+	AdminGraphqlAPIID string      `json:"admin_graphql_api_id,omitempty"`
 }
 
 // MetafieldResource represents the result from the metafields/X.json endpoint

--- a/metafield_test.go
+++ b/metafield_test.go
@@ -90,6 +90,7 @@ func TestMetafieldGet(t *testing.T) {
 		Key:               "app_key",
 		Value:             "app_value",
 		ValueType:         "string",
+		Type:              "string",
 		Namespace:         "affiliates",
 		Description:       "some amaaazing app's value",
 		OwnerId:           1,
@@ -115,6 +116,7 @@ func TestMetafieldCreate(t *testing.T) {
 		Key:       "warehouse",
 		Value:     "25",
 		ValueType: "integer",
+		Type:      "integer",
 	}
 
 	returnedMetafield, err := client.Metafield.Create(metafield)
@@ -136,6 +138,7 @@ func TestMetafieldUpdate(t *testing.T) {
 		ID:        1,
 		Value:     "something new",
 		ValueType: "string",
+		Type:      "string",
 	}
 
 	returnedMetafield, err := client.Metafield.Update(metafield)


### PR DESCRIPTION
Changelog:
Adds `Type` to `MetaField` struct since shopify is deprecating the `ValueType`. 
Refer https://shopify.dev/apps/metafields/definitions/types for definitions and description