### PR TITLE
Adding v3 install/use notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,35 @@ The new home of Conversio's Shopify Go library.
 ## Supported Go Versions
 
 This library has been tested against the following versions of Go
-* 1.10
-* 1.11
-* 1.12
-* 1.13
-* 1.14
-* 1.15
 
-## Install
+- 1.10
+- 1.11
+- 1.12
+- 1.13
+- 1.14
+- 1.15
+
+## Install v3
+
+```console
+$ go get github.com/bold-commerce/go-shopify/v3
+```
+
+## Use v3
+
+```go
+import "github.com/bold-commerce/go-shopify/v3"
+```
+
+This gives you access to the `goshopify` package.
+
+## Install v2
 
 ```console
 $ go get github.com/bold-commerce/go-shopify
 ```
 
-## Use
+## Use v2
 
 ```go
 import "github.com/bold-commerce/go-shopify"
@@ -108,14 +123,17 @@ client := goshopify.NewClient(app, "shopname", "")
 // Fetch the number of products.
 numProducts, err := client.Product.Count(nil)
 ```
+
 ### Client Options
-When creating a client there are configuration options you can pass to NewClient. Simply use the last variadic param and 
+
+When creating a client there are configuration options you can pass to NewClient. Simply use the last variadic param and
 pass in the built in options or create your own and manipulate the client. See [options.go](https://github.com/bold-commerce/go-shopify/blob/master/options.go)
 for more details.
 
 #### WithVersion
+
 Read more details on the [Shopify API Versioning](https://shopify.dev/concepts/about-apis/versioning)
-to understand the format and release schedules. You can use `WithVersion` to specify a specific version 
+to understand the format and release schedules. You can use `WithVersion` to specify a specific version
 of the API. If you do not use this option you will be defaulted to the oldest stable API.
 
 ```go
@@ -123,9 +141,10 @@ client := goshopify.NewClient(app, "shopname", "", goshopify.WithVersion("2019-0
 ```
 
 #### WithRetry
-Shopify [Rate Limits](https://shopify.dev/concepts/about-apis/rate-limits) their API and if this happens to you they 
-will send a back off (usually 2s) to tell you to retry your request. To support this functionality seamlessly within 
-the client a `WithRetry` option exists where you can pass an `int` of how many times you wish to retry per-request 
+
+Shopify [Rate Limits](https://shopify.dev/concepts/about-apis/rate-limits) their API and if this happens to you they
+will send a back off (usually 2s) to tell you to retry your request. To support this functionality seamlessly within
+the client a `WithRetry` option exists where you can pass an `int` of how many times you wish to retry per-request
 before returning an error. `WithRetry` additionally supports retrying HTTP503 errors.
 
 ```go
@@ -202,6 +221,7 @@ In order to be sure that a webhook is sent from ShopifyApi you could easily veri
 it with the `VerifyWebhookRequest` method.
 
 For example:
+
 ```go
 func ValidateWebhook(httpRequest *http.Request) (bool) {
     shopifyApp := goshopify.App{ApiSecret: "ratz"}
@@ -210,38 +230,47 @@ func ValidateWebhook(httpRequest *http.Request) (bool) {
 ```
 
 ## Develop and test
+
 `docker` and `docker-compose` must be installed
 
 ### Mac/Linux/Windows with make
+
 Using the make file is the easiest way to get started with the tests and wraps the manual steps below with easy to use
 make commands.
 
 ```shell
 make && make test
 ```
+
 #### Makefile goals
-* `make` or `make container`: default goal is to make the `go-shopify:latest` build container
-* `make test`: run go test in the container
-* `make clean`: deletes the `go-shopify:latest` image and coverage output
-* `make coverage`: generates the coverage.html and opens it
+
+- `make` or `make container`: default goal is to make the `go-shopify:latest` build container
+- `make test`: run go test in the container
+- `make clean`: deletes the `go-shopify:latest` image and coverage output
+- `make coverage`: generates the coverage.html and opens it
 
 ### Manually
+
 To run the tests you will need the `go-shopify:latest` image built to run your tests, to do this run
+
 ```
 docker-compose build test
 ```
 
 To run tests you can use run
+
 ```shell
 docker-compose run --rm tests
 ```
 
 To create a coverage profile run the following to generate a coverage.html
+
 ```
 docker-compose run --rm dev sh -c 'go test -coverprofile=coverage.out ./... && go tool cover -html coverage.out -o coverage.html'
 ```
 
 When done testing and you want to cleanup simply run
+
 ```
 docker image rm go-shopify:latest
 ```


### PR DESCRIPTION
Documentation does not mention how to install `v3` version of the package.
`v3` is resolving changes with pagination on product listing Shopify API with method ListWithPagination. (With `v2` you cannot get all the products if there are more than 250 of them).

Ive also leave instructions to install previous version.

Resolving: https://github.com/bold-commerce/go-shopify/issues/134
Duplication of: https://github.com/bold-commerce/go-shopify/pull/135 (which was never revisited because of author inactivity)