### PR TITLE
fix: Omit empty API version for webhook

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -36,7 +36,7 @@ type Webhook struct {
 	Fields                     []string   `json:"fields"`
 	MetafieldNamespaces        []string   `json:"metafield_namespaces"`
 	PrivateMetafieldNamespaces []string   `json:"private_metafield_namespaces"`
-	ApiVersion                 string     `json:"api_version"`
+	ApiVersion                 string     `json:"api_version,omitempty"`
 }
 
 // WebhookOptions can be used for filtering webhooks on a List request.


### PR DESCRIPTION
Currently the Create method doesn't work at all, since we always send an empty "api_version" to Shopify. The api_version is read-only, and as such, Shopify doesn't allow you to pass it as an argument at all, therefore the request fails on validation.