### PR TITLE
Add HS (HTS) Code fields, as per fields supported by Shopify's API.

### DIFF
--- a/fixtures/inventory_item.json
+++ b/fixtures/inventory_item.json
@@ -6,6 +6,10 @@
       "updated_at": "2018-10-29T06:05:58-04:00",
       "cost": "25.00",
       "tracked": true,
-      "admin_graphql_api_id": "gid://shopify/InventoryItem/808950810"
+      "admin_graphql_api_id": "gid://shopify/InventoryItem/808950810",
+      "country_code_of_origin": "US",
+      "country_harmonized_system_codes": ["8471.70.40.35", "8471.70.50.35"],
+      "harmonized_system_code": "8471.70.40.35",
+      "province_code_of_origin": "ON"
     }
   }

--- a/inventory_item.go
+++ b/inventory_item.go
@@ -25,13 +25,17 @@ type InventoryItemServiceOp struct {
 
 // InventoryItem represents a Shopify inventory item
 type InventoryItem struct {
-	ID                int64            `json:"id,omitempty"`
-	SKU               string           `json:"sku,omitempty"`
-	CreatedAt         *time.Time       `json:"created_at,omitempty"`
-	UpdatedAt         *time.Time       `json:"updated_at,omitempty"`
-	Cost              *decimal.Decimal `json:"cost,omitempty"`
-	Tracked           *bool            `json:"tracked,omitempty"`
-	AdminGraphqlAPIID string           `json:"admin_graphql_api_id,omitempty"`
+	ID                           int64            `json:"id,omitempty"`
+	SKU                          string           `json:"sku,omitempty"`
+	CreatedAt                    *time.Time       `json:"created_at,omitempty"`
+	UpdatedAt                    *time.Time       `json:"updated_at,omitempty"`
+	Cost                         *decimal.Decimal `json:"cost,omitempty"`
+	Tracked                      *bool            `json:"tracked,omitempty"`
+	AdminGraphqlAPIID            string           `json:"admin_graphql_api_id,omitempty"`
+	CountryCodeOfOrigin          *string          `json:"country_code_of_origin"`
+	CountryHarmonizedSystemCodes []string         `json:"country_harmonized_system_codes"`
+	HarmonizedSystemCode         *string          `json:"harmonized_system_code"`
+	ProvinceCodeOfOrigin         *string          `json:"province_code_of_origin"`
 }
 
 // InventoryItemResource is used for handling single item requests and responses

--- a/inventory_item_test.go
+++ b/inventory_item_test.go
@@ -2,6 +2,7 @@ package goshopify
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
@@ -32,6 +33,28 @@ func inventoryItemTests(t *testing.T, item *InventoryItem) {
 	costFloat, _ := item.Cost.Float64()
 	if costFloat != expectedCost {
 		t.Errorf("InventoryItem.Cost (float) is %+v, expected %+v", costFloat, expectedCost)
+	}
+
+	expectedOrigin := "US"
+	if *item.CountryCodeOfOrigin != expectedOrigin {
+		t.Errorf("InventoryItem.CountryCodeOfOrigin returned %+v, expected %+v", item.CountryCodeOfOrigin, expectedOrigin)
+	}
+
+	//strings.Join is used to compare slices since package's go.mod is set to 1.13
+	//which predates the experimental slices package that has a Compare() func.
+	expectedCountryHSCodes := strings.Join([]string{"8471.70.40.35", "8471.70.50.35"}, ",")
+	if strings.Join(item.CountryHarmonizedSystemCodes, ",") != expectedCountryHSCodes {
+		t.Errorf("InventoryItem.CountryHarmonizedSystemCodes returned %+v, expected %+v", item.CountryHarmonizedSystemCodes, expectedCountryHSCodes)
+	}
+
+	expectedHSCode := "8471.70.40.35"
+	if *item.HarmonizedSystemCode != expectedHSCode {
+		t.Errorf("InventoryItem.HarmonizedSystemCode returned %+v, expected %+v", item.CountryHarmonizedSystemCodes, expectedHSCode)
+	}
+
+	expectedProvince := "ON"
+	if *item.ProvinceCodeOfOrigin != expectedProvince {
+		t.Errorf("InventoryItem.ProvinceCodeOfOrigin returned %+v, expected %+v", item.ProvinceCodeOfOrigin, expectedHSCode)
 	}
 }
 


### PR DESCRIPTION
This PR adds fields to handle Harmonized Tariff Schedule codes to the InventoryItem type.  These fields exist in [Shopify's API docs](https://shopify.dev/docs/api/admin-rest/2023-04/resources/inventoryitem#resource-object) and are used to handle international shipments.