### PR TITLE
Remove ValueType field from Metafields since it was deprecated.

### DIFF
--- a/customcollection_test.go
+++ b/customcollection_test.go
@@ -237,7 +237,6 @@ func TestCustomCollectionCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		ValueType: "string",
 		Type:      "single_line_text_field",
 		Namespace: "affiliates",
 	}
@@ -261,7 +260,6 @@ func TestCustomCollectionUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		ValueType: "string",
 		Type:      "single_line_text_field",
 		Namespace: "affiliates",
 	}

--- a/customer_test.go
+++ b/customer_test.go
@@ -494,7 +494,6 @@ func TestCustomerCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		ValueType: "string",
 		Type:      "single_line_text_field",
 		Namespace: "affiliates",
 	}
@@ -518,7 +517,6 @@ func TestCustomerUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		ValueType: "string",
 		Type:      "single_line_text_field",
 		Namespace: "affiliates",
 	}

--- a/draft_order_test.go
+++ b/draft_order_test.go
@@ -360,7 +360,6 @@ func TestDraftOrderCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		ValueType: "string",
 		Namespace: "affiliates",
 	}
 
@@ -383,7 +382,6 @@ func TestDraftOrderUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		ValueType: "string",
 		Namespace: "affiliates",
 	}
 

--- a/fixtures/metafield.json
+++ b/fixtures/metafield.json
@@ -4,7 +4,6 @@
     "namespace": "affiliates",
     "key": "app_key",
     "value": "app_value",
-    "value_type": "string",
     "type": "single_line_text_field",
     "description": "some amaaazing app's value",
     "owner_id": 1,

--- a/metafield.go
+++ b/metafield.go
@@ -42,7 +42,6 @@ type Metafield struct {
 	ID                int64       `json:"id,omitempty"`
 	Key               string      `json:"key,omitempty"`
 	Value             interface{} `json:"value,omitempty"`
-	ValueType         string      `json:"value_type,omitempty"`
 	Type              string      `json:"type,omitempty"`
 	Namespace         string      `json:"namespace,omitempty"`
 	Description       string      `json:"description,omitempty"`

--- a/metafield_test.go
+++ b/metafield_test.go
@@ -89,7 +89,6 @@ func TestMetafieldGet(t *testing.T) {
 		ID:                1,
 		Key:               "app_key",
 		Value:             "app_value",
-		ValueType:         "string",
 		Type:              "single_line_text_field",
 		Namespace:         "affiliates",
 		Description:       "some amaaazing app's value",
@@ -115,7 +114,6 @@ func TestMetafieldCreate(t *testing.T) {
 		Namespace: "inventory",
 		Key:       "warehouse",
 		Value:     "25",
-		ValueType: "integer",
 		Type:      "single_line_text_field",
 	}
 
@@ -135,10 +133,9 @@ func TestMetafieldUpdate(t *testing.T) {
 		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
 
 	metafield := Metafield{
-		ID:        1,
-		Value:     "something new",
-		ValueType: "string",
-		Type:      "single_line_text_field",
+		ID:    1,
+		Value: "something new",
+		Type:  "single_line_text_field",
 	}
 
 	returnedMetafield, err := client.Metafield.Update(metafield)

--- a/order_test.go
+++ b/order_test.go
@@ -553,7 +553,6 @@ func TestOrderCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		ValueType: "string",
 		Type:      "single_line_text_field",
 		Namespace: "affiliates",
 	}
@@ -577,7 +576,6 @@ func TestOrderUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		ValueType: "string",
 		Type:      "single_line_text_field",
 		Namespace: "affiliates",
 	}

--- a/page_test.go
+++ b/page_test.go
@@ -223,7 +223,6 @@ func TestPageCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		ValueType: "string",
 		Type:      "single_line_text_field",
 		Namespace: "affiliates",
 	}
@@ -247,7 +246,6 @@ func TestPageUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		ValueType: "string",
 		Type:      "single_line_text_field",
 		Namespace: "affiliates",
 	}

--- a/product_test.go
+++ b/product_test.go
@@ -392,7 +392,6 @@ func TestProductCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		ValueType: "string",
 		Type:      "single_line_text_field",
 		Namespace: "affiliates",
 	}
@@ -416,7 +415,6 @@ func TestProductUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		ValueType: "string",
 		Type:      "single_line_text_field",
 		Namespace: "affiliates",
 	}

--- a/smartcollection_test.go
+++ b/smartcollection_test.go
@@ -240,7 +240,6 @@ func TestSmartCollectionCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		ValueType: "string",
 		Type:      "single_line_text_field",
 		Namespace: "affiliates",
 	}
@@ -264,7 +263,6 @@ func TestSmartCollectionUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		ValueType: "string",
 		Type:      "single_line_text_field",
 		Namespace: "affiliates",
 	}

--- a/variant_test.go
+++ b/variant_test.go
@@ -320,7 +320,6 @@ func TestVariantCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		ValueType: "string",
 		Type:      "single_line_text_field",
 		Namespace: "affiliates",
 	}
@@ -344,7 +343,6 @@ func TestVariantUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		ValueType: "string",
 		Type:      "single_line_text_field",
 		Namespace: "affiliates",
 	}


### PR DESCRIPTION
The `ValueType` field of a Metafield was deprecated some time long ago (2021?).  As of API version 2023-07 it is no longer supported.  The `Type` field should be used instead.  This removes the `ValueType` field from the `Metafield` type.