### PR TITLE
Define consts for well known values.

### DIFF
--- a/customcollection_test.go
+++ b/customcollection_test.go
@@ -237,7 +237,7 @@ func TestCustomCollectionCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "single_line_text_field",
+		Type:      MetafieldTypeSingleLineTextField,
 		Namespace: "affiliates",
 	}
 
@@ -260,7 +260,7 @@ func TestCustomCollectionUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "single_line_text_field",
+		Type:      MetafieldTypeSingleLineTextField,
 		Namespace: "affiliates",
 	}
 

--- a/customer_test.go
+++ b/customer_test.go
@@ -494,7 +494,7 @@ func TestCustomerCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "single_line_text_field",
+		Type:      MetafieldTypeSingleLineTextField,
 		Namespace: "affiliates",
 	}
 
@@ -517,7 +517,7 @@ func TestCustomerUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "single_line_text_field",
+		Type:      "MetafieldTypeSingleLineTextField_text_field",
 		Namespace: "affiliates",
 	}
 

--- a/customer_test.go
+++ b/customer_test.go
@@ -517,7 +517,7 @@ func TestCustomerUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "MetafieldTypeSingleLineTextField_text_field",
+		Type:      MetafieldTypeSingleLineTextField,
 		Namespace: "affiliates",
 	}
 

--- a/draft_order.go
+++ b/draft_order.go
@@ -100,22 +100,22 @@ type DraftOrderInvoiceResource struct {
 // DraftOrderListOptions represents the possible options that can be used
 // to further query the list draft orders endpoint
 type DraftOrderListOptions struct {
-	Fields       string     `url:"fields,omitempty"`
-	Limit        int        `url:"limit,omitempty"`
-	SinceID      int64      `url:"since_id,omitempty"`
-	UpdatedAtMin *time.Time `url:"updated_at_min,omitempty"`
-	UpdatedAtMax *time.Time `url:"updated_at_max,omitempty"`
-	IDs          string     `url:"ids,omitempty"`
-	Status       string     `url:"status,omitempty"`
+	Fields       string      `url:"fields,omitempty"`
+	Limit        int         `url:"limit,omitempty"`
+	SinceID      int64       `url:"since_id,omitempty"`
+	UpdatedAtMin *time.Time  `url:"updated_at_min,omitempty"`
+	UpdatedAtMax *time.Time  `url:"updated_at_max,omitempty"`
+	IDs          string      `url:"ids,omitempty"`
+	Status       orderStatus `url:"status,omitempty"`
 }
 
 // DraftOrderCountOptions represents the possible options to the count draft orders endpoint
 type DraftOrderCountOptions struct {
-	Fields  string `url:"fields,omitempty"`
-	Limit   int    `url:"limit,omitempty"`
-	SinceID int64  `url:"since_id,omitempty"`
-	IDs     string `url:"ids,omitempty"`
-	Status  string `url:"status,omitempty"`
+	Fields  string      `url:"fields,omitempty"`
+	Limit   int         `url:"limit,omitempty"`
+	SinceID int64       `url:"since_id,omitempty"`
+	IDs     string      `url:"ids,omitempty"`
+	Status  orderStatus `url:"status,omitempty"`
 }
 
 // Create draft order

--- a/draft_order_test.go
+++ b/draft_order_test.go
@@ -139,7 +139,7 @@ func TestDraftOrderCount(t *testing.T) {
 		t.Errorf("DraftOrder.Count returned %d, expected %d", cnt, expected)
 	}
 
-	status := "open"
+	status := StatusOpen
 	cnt, err = client.DraftOrder.Count(DraftOrderCountOptions{Status: status})
 	if err != nil {
 		t.Errorf("DraftOrder.Count returned an error: %v", err)
@@ -186,7 +186,7 @@ func TestDraftOrderListOptions(t *testing.T) {
 
 	options := DraftOrderListOptions{
 		Limit:  250,
-		Status: "any",
+		Status: StatusAny,
 		Fields: "id,name",
 	}
 

--- a/draft_order_test.go
+++ b/draft_order_test.go
@@ -139,7 +139,7 @@ func TestDraftOrderCount(t *testing.T) {
 		t.Errorf("DraftOrder.Count returned %d, expected %d", cnt, expected)
 	}
 
-	status := StatusOpen
+	status := OrderStatusOpen
 	cnt, err = client.DraftOrder.Count(DraftOrderCountOptions{Status: status})
 	if err != nil {
 		t.Errorf("DraftOrder.Count returned an error: %v", err)
@@ -186,7 +186,7 @@ func TestDraftOrderListOptions(t *testing.T) {
 
 	options := DraftOrderListOptions{
 		Limit:  250,
-		Status: StatusAny,
+		Status: OrderStatusAny,
 		Fields: "id,name",
 	}
 

--- a/fixtures/metafield.json
+++ b/fixtures/metafield.json
@@ -4,7 +4,7 @@
     "namespace": "affiliates",
     "key": "app_key",
     "value": "app_value",
-    "type": "single_line_text_field",
+    "type": "MetafieldTypeSingleLineTextField_text_field",
     "description": "some amaaazing app's value",
     "owner_id": 1,
     "created_at": "2016-01-01T00:00:00Z",

--- a/fixtures/metafield.json
+++ b/fixtures/metafield.json
@@ -4,7 +4,7 @@
     "namespace": "affiliates",
     "key": "app_key",
     "value": "app_value",
-    "type": "MetafieldTypeSingleLineTextField_text_field",
+    "type": "single_line_text_field",
     "description": "some amaaazing app's value",
     "owner_id": 1,
     "created_at": "2016-01-01T00:00:00Z",

--- a/metafield.go
+++ b/metafield.go
@@ -78,7 +78,7 @@ const (
 	MetafieldTypeRichTextField metafieldType = "rich_text_field"
 
 	//A single line of text. Do not use for numbers or dates, use correct type instead!
-	MetafieldTypeSingleLineTextField metafieldType = "MetafieldTypeSingleLineTextField_text_field"
+	MetafieldTypeSingleLineTextField metafieldType = "single_line_text_field"
 
 	//https, http, mailto, sms, or tel.
 	MetafieldTypeURL metafieldType = "url"

--- a/metafield.go
+++ b/metafield.go
@@ -37,19 +37,72 @@ type MetafieldServiceOp struct {
 	resourceID int64
 }
 
+type metafieldType string
+
+// https://shopify.dev/docs/api/admin-rest/2023-07/resources/metafield#resource-object
+const (
+	//True or false.
+	MetafieldTypeBoolean metafieldType = "boolean"
+
+	//A hexidecimal color code, #fff123.
+	MetafieldTypeColor metafieldType = "color" //#fff123
+
+	//ISO601, YYYY-MM-DD.
+	MetafieldTypeDate metafieldType = "date"
+
+	//ISO8601, YYYY-MM-DDTHH:MM:SS.
+	MetafieldTypeDatetime metafieldType = "date_time"
+
+	//JSON, {"value:" 25.0, "unit": "cm"}.
+	MetafieldTypeDimension metafieldType = "dimension"
+
+	//{"ingredient": "flour", "amount": 0.3}.
+	MetafieldTypeJSON metafieldType = "json"
+
+	//JSON, {"amount": 5.99, "currency_code": "CAD"}.
+	MetafieldTypeMoney metafieldType = "money"
+
+	//lines of text separated with newline characters.
+	MetafieldTypeMultiLineTextField metafieldType = "multi_line_text_field"
+
+	//10.4.
+	MetafieldTypeNumberDecimal metafieldType = "number_decimal"
+
+	//10.
+	MetafieldTypeNumberInteger metafieldType = "number_integer"
+
+	//JSON, {"value": "3.5", "scale_min": "1.0", "scale_max": "5.0"}.
+	MetafieldTypeRating metafieldType = "rating"
+
+	//JSON, {"type": "root","children": [{"type": "paragraph","children": [{"type": "text","value": "Bold text.","bold": true}]}]}.
+	MetafieldTypeRichTextField metafieldType = "rich_text_field"
+
+	//A single line of text. Do not use for numbers or dates, use correct type instead!
+	MetafieldTypeSingleLineTextField metafieldType = "MetafieldTypeSingleLineTextField_text_field"
+
+	//https, http, mailto, sms, or tel.
+	MetafieldTypeURL metafieldType = "url"
+
+	//JSON, {"value:" 20.0, "unit": "ml"}.
+	MetafieldTypeVolume metafieldType = "volume"
+
+	//JSON, {"value:" 2.5, "unit": "kg"}.
+	MetafieldTypeWeight metafieldType = "weight"
+)
+
 // Metafield represents a Shopify metafield.
 type Metafield struct {
-	ID                int64       `json:"id,omitempty"`
-	Key               string      `json:"key,omitempty"`
-	Value             interface{} `json:"value,omitempty"`
-	Type              string      `json:"type,omitempty"`
-	Namespace         string      `json:"namespace,omitempty"`
-	Description       string      `json:"description,omitempty"`
-	OwnerId           int64       `json:"owner_id,omitempty"`
-	CreatedAt         *time.Time  `json:"created_at,omitempty"`
-	UpdatedAt         *time.Time  `json:"updated_at,omitempty"`
-	OwnerResource     string      `json:"owner_resource,omitempty"`
-	AdminGraphqlAPIID string      `json:"admin_graphql_api_id,omitempty"`
+	CreatedAt         *time.Time    `json:"created_at,omitempty"`
+	Description       string        `json:"description,omitempty"`    //Description of the metafield.
+	ID                int64         `json:"id,omitempty"`             //Assigned by Shopify, used for updating a metafield.
+	Key               string        `json:"key,omitempty"`            //The unique identifier for a metafield within its namespace, 3-64 characters long.
+	Namespace         string        `json:"namespace,omitempty"`      //The container for a group of metafields, 3-255 characters long.
+	OwnerId           int64         `json:"owner_id,omitempty"`       //The unique ID of the resource the metafield is for, i.e.: an Order ID.
+	OwnerResource     string        `json:"owner_resource,omitempty"` //The type of reserouce the metafield is for, i.e.: and Order.
+	UpdatedAt         *time.Time    `json:"updated_at,omitempty"`     //
+	Value             interface{}   `json:"value,omitempty"`          //The data stored in the metafield. Always stored as a string, use Type field for actual data type.
+	Type              metafieldType `json:"type,omitempty"`           //One of Shopify's defined types, see metafieldType.
+	AdminGraphqlAPIID string        `json:"admin_graphql_api_id,omitempty"`
 }
 
 // MetafieldResource represents the result from the metafields/X.json endpoint

--- a/metafield_test.go
+++ b/metafield_test.go
@@ -89,7 +89,7 @@ func TestMetafieldGet(t *testing.T) {
 		ID:                1,
 		Key:               "app_key",
 		Value:             "app_value",
-		Type:              "single_line_text_field",
+		Type:              MetafieldTypeSingleLineTextField,
 		Namespace:         "affiliates",
 		Description:       "some amaaazing app's value",
 		OwnerId:           1,
@@ -113,8 +113,8 @@ func TestMetafieldCreate(t *testing.T) {
 	metafield := Metafield{
 		Namespace: "inventory",
 		Key:       "warehouse",
-		Value:     "25",
-		Type:      "single_line_text_field",
+		Value:     25,
+		Type:      MetafieldTypeNumberInteger,
 	}
 
 	returnedMetafield, err := client.Metafield.Create(metafield)
@@ -135,7 +135,7 @@ func TestMetafieldUpdate(t *testing.T) {
 	metafield := Metafield{
 		ID:    1,
 		Value: "something new",
-		Type:  "single_line_text_field",
+		Type:  MetafieldTypeSingleLineTextField,
 	}
 
 	returnedMetafield, err := client.Metafield.Update(metafield)

--- a/order.go
+++ b/order.go
@@ -44,16 +44,16 @@ type orderStatus string
 // https://shopify.dev/docs/api/admin-rest/2023-07/resources/order#get-orders?status=any
 const (
 	//Show only open orders.
-	StatusOpen orderStatus = "open"
+	OrderStatusOpen orderStatus = "open"
 
 	//Show only closed orders.
-	StatusClosed orderStatus = "closed"
+	OrderStatusClosed orderStatus = "closed"
 
 	//Show only cancelled orders.
-	StatusCancelled orderStatus = "cancelled"
+	OrderStatusCancelled orderStatus = "cancelled"
 
 	//Show orders of any status, open, closed, cancellerd, or archived.
-	StatusAny orderStatus = "any"
+	OrderStatusAny orderStatus = "any"
 )
 
 type orderFulfillmentStatus string
@@ -61,24 +61,24 @@ type orderFulfillmentStatus string
 // https://shopify.dev/docs/api/admin-rest/2023-07/resources/order#get-orders?status=any
 const (
 	//Show orders that have been shipped.
-	FulfillmentStatusShipped orderFulfillmentStatus = "shipped"
+	OrderFulfillmentStatusShipped orderFulfillmentStatus = "shipped"
 
 	//Show partially shipped orders.
-	FulfillmentStatusPartial orderFulfillmentStatus = "partial"
+	OrderFulfillmentStatusPartial orderFulfillmentStatus = "partial"
 
 	//Show orders that have not yet been shipped.
-	FulfillmentStatusUnshipped orderFulfillmentStatus = "unshipped"
+	OrderFulfillmentStatusUnshipped orderFulfillmentStatus = "unshipped"
 
 	//Show orders of any fulfillment status.
-	FulfillmentStatusAny orderFulfillmentStatus = "any"
+	OrderFulfillmentStatusAny orderFulfillmentStatus = "any"
 
 	//Returns orders with fulfillment_status of null or partial.
-	FulfillmentStatusUnfulfilled orderFulfillmentStatus = "unfulfilled"
+	OrderFulfillmentStatusUnfulfilled orderFulfillmentStatus = "unfulfilled"
 
 	//"fulfilled" used to be an acceptable value? Was it deprecated? It isn't noted
 	//in the Shopify docs at the provided URL, but it was used in tests and still
 	//seems to function.
-	FulfillmentStatusFulfilled orderFulfillmentStatus = "fulfilled"
+	OrderFulfillmentStatusFulfilled orderFulfillmentStatus = "fulfilled"
 )
 
 type orderFinancialStatus string
@@ -86,50 +86,50 @@ type orderFinancialStatus string
 // https://shopify.dev/docs/api/admin-rest/2023-07/resources/order#get-orders?status=any
 const (
 	//Show only authorized orders.
-	FinancialStatusAuthorized orderFinancialStatus = "authorized"
+	OrderFinancialStatusAuthorized orderFinancialStatus = "authorized"
 
 	//Show only pending orders.
-	FinancialStatusPending orderFinancialStatus = "pending"
+	OrderFinancialStatusPending orderFinancialStatus = "pending"
 
 	//Show only paid orders.
-	FinancialStatusPaid orderFinancialStatus = "paid"
+	OrderFinancialStatusPaid orderFinancialStatus = "paid"
 
 	//Show only partially paid orders.
-	FinancialStatusPartiallyPaid orderFinancialStatus = "partially_paid"
+	OrderFinancialStatusPartiallyPaid orderFinancialStatus = "partially_paid"
 
 	//Show only refunded orders.
-	FinancialStatusRefunded orderFinancialStatus = "refunded"
+	OrderFinancialStatusRefunded orderFinancialStatus = "refunded"
 
 	//Show only voided orders.
-	FinancialStatusVoided orderFinancialStatus = "voided"
+	OrderFinancialStatusVoided orderFinancialStatus = "voided"
 
 	//Show only partially refunded orders.
-	FinancialStatusPartiallyRefunded orderFinancialStatus = "partially_refunded"
+	OrderFinancialStatusPartiallyRefunded orderFinancialStatus = "partially_refunded"
 
 	//Show orders of any financial status.
-	FinancialStatusAny orderFinancialStatus = "any"
+	OrderFinancialStatusAny orderFinancialStatus = "any"
 
 	//Show authorized and partially paid orders.
-	FinancialStatusUnpaid orderFinancialStatus = "unpaid"
+	OrderFinancialStatusUnpaid orderFinancialStatus = "unpaid"
 )
 
 type orderCancelReason string
 
 const (
 	//The customer canceled the order.
-	CancelReasonCustomer orderCancelReason = "customer"
+	OrderCancelReasonCustomer orderCancelReason = "customer"
 
 	//The order was fraudulent.
-	CancelReasonFraud orderCancelReason = "fraud"
+	OrderCancelReasonFraud orderCancelReason = "fraud"
 
 	//Items in the order were not in inventory.
-	CancelReasonInventory orderCancelReason = "inventory"
+	OrderCancelReasonInventory orderCancelReason = "inventory"
 
 	//The payment was declined.
-	CancelReasonDeclined orderCancelReason = "declined"
+	OrderCancelReasonDeclined orderCancelReason = "declined"
 
 	//Cancelled for some other reason.
-	CancelReasonOther orderCancelReason = "other"
+	OrderCancelReasonOther orderCancelReason = "other"
 )
 
 // A struct for all available order count options

--- a/order.go
+++ b/order.go
@@ -39,32 +39,125 @@ type OrderServiceOp struct {
 	client *Client
 }
 
+type orderStatus string
+
+// https://shopify.dev/docs/api/admin-rest/2023-07/resources/order#get-orders?status=any
+const (
+	//Show only open orders.
+	StatusOpen orderStatus = "open"
+
+	//Show only closed orders.
+	StatusClosed orderStatus = "closed"
+
+	//Show only cancelled orders.
+	StatusCancelled orderStatus = "cancelled"
+
+	//Show orders of any status, open, closed, cancellerd, or archived.
+	StatusAny orderStatus = "any"
+)
+
+type orderFulfillmentStatus string
+
+// https://shopify.dev/docs/api/admin-rest/2023-07/resources/order#get-orders?status=any
+const (
+	//Show orders that have been shipped.
+	FulfillmentStatusShipped orderFulfillmentStatus = "shipped"
+
+	//Show partially shipped orders.
+	FulfillmentStatusPartial orderFulfillmentStatus = "partial"
+
+	//Show orders that have not yet been shipped.
+	FulfillmentStatusUnshipped orderFulfillmentStatus = "unshipped"
+
+	//Show orders of any fulfillment status.
+	FulfillmentStatusAny orderFulfillmentStatus = "any"
+
+	//Returns orders with fulfillment_status of null or partial.
+	FulfillmentStatusUnfulfilled orderFulfillmentStatus = "unfulfilled"
+
+	//"fulfilled" used to be an acceptable value? Was it deprecated? It isn't noted
+	//in the Shopify docs at the provided URL, but it was used in tests and still
+	//seems to function.
+	FulfillmentStatusFulfilled orderFulfillmentStatus = "fulfilled"
+)
+
+type orderFinancialStatus string
+
+// https://shopify.dev/docs/api/admin-rest/2023-07/resources/order#get-orders?status=any
+const (
+	//Show only authorized orders.
+	FinancialStatusAuthorized orderFinancialStatus = "authorized"
+
+	//Show only pending orders.
+	FinancialStatusPending orderFinancialStatus = "pending"
+
+	//Show only paid orders.
+	FinancialStatusPaid orderFinancialStatus = "paid"
+
+	//Show only partially paid orders.
+	FinancialStatusPartiallyPaid orderFinancialStatus = "partially_paid"
+
+	//Show only refunded orders.
+	FinancialStatusRefunded orderFinancialStatus = "refunded"
+
+	//Show only voided orders.
+	FinancialStatusVoided orderFinancialStatus = "voided"
+
+	//Show only partially refunded orders.
+	FinancialStatusPartiallyRefunded orderFinancialStatus = "partially_refunded"
+
+	//Show orders of any financial status.
+	FinancialStatusAny orderFinancialStatus = "any"
+
+	//Show authorized and partially paid orders.
+	FinancialStatusUnpaid orderFinancialStatus = "unpaid"
+)
+
+type orderCancelReason string
+
+const (
+	//The customer canceled the order.
+	CancelReasonCustomer orderCancelReason = "customer"
+
+	//The order was fraudulent.
+	CancelReasonFraud orderCancelReason = "fraud"
+
+	//Items in the order were not in inventory.
+	CancelReasonInventory orderCancelReason = "inventory"
+
+	//The payment was declined.
+	CancelReasonDeclined orderCancelReason = "declined"
+
+	//Cancelled for some other reason.
+	CancelReasonOther orderCancelReason = "other"
+)
+
 // A struct for all available order count options
 type OrderCountOptions struct {
-	Page              int       `url:"page,omitempty"`
-	Limit             int       `url:"limit,omitempty"`
-	SinceID           int64     `url:"since_id,omitempty"`
-	CreatedAtMin      time.Time `url:"created_at_min,omitempty"`
-	CreatedAtMax      time.Time `url:"created_at_max,omitempty"`
-	UpdatedAtMin      time.Time `url:"updated_at_min,omitempty"`
-	UpdatedAtMax      time.Time `url:"updated_at_max,omitempty"`
-	Order             string    `url:"order,omitempty"`
-	Fields            string    `url:"fields,omitempty"`
-	Status            string    `url:"status,omitempty"`
-	FinancialStatus   string    `url:"financial_status,omitempty"`
-	FulfillmentStatus string    `url:"fulfillment_status,omitempty"`
+	Page              int                    `url:"page,omitempty"`
+	Limit             int                    `url:"limit,omitempty"`
+	SinceID           int64                  `url:"since_id,omitempty"`
+	CreatedAtMin      time.Time              `url:"created_at_min,omitempty"`
+	CreatedAtMax      time.Time              `url:"created_at_max,omitempty"`
+	UpdatedAtMin      time.Time              `url:"updated_at_min,omitempty"`
+	UpdatedAtMax      time.Time              `url:"updated_at_max,omitempty"`
+	Order             string                 `url:"order,omitempty"`
+	Fields            string                 `url:"fields,omitempty"`
+	Status            orderStatus            `url:"status,omitempty"`
+	FinancialStatus   orderFinancialStatus   `url:"financial_status,omitempty"`
+	FulfillmentStatus orderFulfillmentStatus `url:"fulfillment_status,omitempty"`
 }
 
 // A struct for all available order list options.
 // See: https://help.shopify.com/api/reference/order#index
 type OrderListOptions struct {
 	ListOptions
-	Status            string    `url:"status,omitempty"`
-	FinancialStatus   string    `url:"financial_status,omitempty"`
-	FulfillmentStatus string    `url:"fulfillment_status,omitempty"`
-	ProcessedAtMin    time.Time `url:"processed_at_min,omitempty"`
-	ProcessedAtMax    time.Time `url:"processed_at_max,omitempty"`
-	Order             string    `url:"order,omitempty"`
+	Status            orderStatus            `url:"status,omitempty"`
+	FinancialStatus   orderFinancialStatus   `url:"financial_status,omitempty"`
+	FulfillmentStatus orderFulfillmentStatus `url:"fulfillment_status,omitempty"`
+	ProcessedAtMin    time.Time              `url:"processed_at_min,omitempty"`
+	ProcessedAtMax    time.Time              `url:"processed_at_max,omitempty"`
+	Order             string                 `url:"order,omitempty"`
 }
 
 // A struct of all available order cancel options.
@@ -80,75 +173,75 @@ type OrderCancelOptions struct {
 
 // Order represents a Shopify order
 type Order struct {
-	ID                     int64            `json:"id,omitempty"`
-	Name                   string           `json:"name,omitempty"`
-	Email                  string           `json:"email,omitempty"`
-	CreatedAt              *time.Time       `json:"created_at,omitempty"`
-	UpdatedAt              *time.Time       `json:"updated_at,omitempty"`
-	CancelledAt            *time.Time       `json:"cancelled_at,omitempty"`
-	ClosedAt               *time.Time       `json:"closed_at,omitempty"`
-	ProcessedAt            *time.Time       `json:"processed_at,omitempty"`
-	Customer               *Customer        `json:"customer,omitempty"`
-	BillingAddress         *Address         `json:"billing_address,omitempty"`
-	ShippingAddress        *Address         `json:"shipping_address,omitempty"`
-	Currency               string           `json:"currency,omitempty"`
-	TotalPrice             *decimal.Decimal `json:"total_price,omitempty"`
-	CurrentTotalPrice      *decimal.Decimal `json:"current_total_price,omitempty"`
-	SubtotalPrice          *decimal.Decimal `json:"subtotal_price,omitempty"`
-	CurrentSubtotalPrice   *decimal.Decimal `json:"current_subtotal_price,omitempty"`
-	TotalDiscounts         *decimal.Decimal `json:"total_discounts,omitempty"`
-	CurrentTotalDiscounts  *decimal.Decimal `json:"current_total_discounts,omitempty"`
-	TotalLineItemsPrice    *decimal.Decimal `json:"total_line_items_price,omitempty"`
-	TaxesIncluded          bool             `json:"taxes_included,omitempty"`
-	TotalTax               *decimal.Decimal `json:"total_tax,omitempty"`
-	CurrentTotalTax        *decimal.Decimal `json:"current_total_tax,omitempty"`
-	TaxLines               []TaxLine        `json:"tax_lines,omitempty"`
-	TotalWeight            int              `json:"total_weight,omitempty"`
-	FinancialStatus        string           `json:"financial_status,omitempty"`
-	Fulfillments           []Fulfillment    `json:"fulfillments,omitempty"`
-	FulfillmentStatus      string           `json:"fulfillment_status,omitempty"`
-	Token                  string           `json:"token,omitempty"`
-	CartToken              string           `json:"cart_token,omitempty"`
-	Number                 int              `json:"number,omitempty"`
-	OrderNumber            int              `json:"order_number,omitempty"`
-	Note                   string           `json:"note,omitempty"`
-	Test                   bool             `json:"test,omitempty"`
-	BrowserIp              string           `json:"browser_ip,omitempty"`
-	BuyerAcceptsMarketing  bool             `json:"buyer_accepts_marketing,omitempty"`
-	CancelReason           string           `json:"cancel_reason,omitempty"`
-	NoteAttributes         []NoteAttribute  `json:"note_attributes,omitempty"`
-	DiscountCodes          []DiscountCode   `json:"discount_codes,omitempty"`
-	LineItems              []LineItem       `json:"line_items,omitempty"`
-	ShippingLines          []ShippingLines  `json:"shipping_lines,omitempty"`
-	Transactions           []Transaction    `json:"transactions,omitempty"`
-	AppID                  int              `json:"app_id,omitempty"`
-	CustomerLocale         string           `json:"customer_locale,omitempty"`
-	LandingSite            string           `json:"landing_site,omitempty"`
-	ReferringSite          string           `json:"referring_site,omitempty"`
-	SourceName             string           `json:"source_name,omitempty"`
-	ClientDetails          *ClientDetails   `json:"client_details,omitempty"`
-	Tags                   string           `json:"tags,omitempty"`
-	LocationId             int64            `json:"location_id,omitempty"`
-	PaymentGatewayNames    []string         `json:"payment_gateway_names,omitempty"`
-	ProcessingMethod       string           `json:"processing_method,omitempty"`
-	Refunds                []Refund         `json:"refunds,omitempty"`
-	UserId                 int64            `json:"user_id,omitempty"`
-	OrderStatusUrl         string           `json:"order_status_url,omitempty"`
-	Gateway                string           `json:"gateway,omitempty"`
-	Confirmed              bool             `json:"confirmed,omitempty"`
-	TotalPriceUSD          *decimal.Decimal `json:"total_price_usd,omitempty"`
-	CheckoutToken          string           `json:"checkout_token,omitempty"`
-	Reference              string           `json:"reference,omitempty"`
-	SourceIdentifier       string           `json:"source_identifier,omitempty"`
-	SourceURL              string           `json:"source_url,omitempty"`
-	DeviceID               int64            `json:"device_id,omitempty"`
-	Phone                  string           `json:"phone,omitempty"`
-	LandingSiteRef         string           `json:"landing_site_ref,omitempty"`
-	CheckoutID             int64            `json:"checkout_id,omitempty"`
-	ContactEmail           string           `json:"contact_email,omitempty"`
-	Metafields             []Metafield      `json:"metafields,omitempty"`
-	SendReceipt            bool             `json:"send_receipt,omitempty"`
-	SendFulfillmentReceipt bool             `json:"send_fulfillment_receipt,omitempty"`
+	ID                     int64                  `json:"id,omitempty"`
+	Name                   string                 `json:"name,omitempty"`
+	Email                  string                 `json:"email,omitempty"`
+	CreatedAt              *time.Time             `json:"created_at,omitempty"`
+	UpdatedAt              *time.Time             `json:"updated_at,omitempty"`
+	CancelledAt            *time.Time             `json:"cancelled_at,omitempty"`
+	ClosedAt               *time.Time             `json:"closed_at,omitempty"`
+	ProcessedAt            *time.Time             `json:"processed_at,omitempty"`
+	Customer               *Customer              `json:"customer,omitempty"`
+	BillingAddress         *Address               `json:"billing_address,omitempty"`
+	ShippingAddress        *Address               `json:"shipping_address,omitempty"`
+	Currency               string                 `json:"currency,omitempty"`
+	TotalPrice             *decimal.Decimal       `json:"total_price,omitempty"`
+	CurrentTotalPrice      *decimal.Decimal       `json:"current_total_price,omitempty"`
+	SubtotalPrice          *decimal.Decimal       `json:"subtotal_price,omitempty"`
+	CurrentSubtotalPrice   *decimal.Decimal       `json:"current_subtotal_price,omitempty"`
+	TotalDiscounts         *decimal.Decimal       `json:"total_discounts,omitempty"`
+	CurrentTotalDiscounts  *decimal.Decimal       `json:"current_total_discounts,omitempty"`
+	TotalLineItemsPrice    *decimal.Decimal       `json:"total_line_items_price,omitempty"`
+	TaxesIncluded          bool                   `json:"taxes_included,omitempty"`
+	TotalTax               *decimal.Decimal       `json:"total_tax,omitempty"`
+	CurrentTotalTax        *decimal.Decimal       `json:"current_total_tax,omitempty"`
+	TaxLines               []TaxLine              `json:"tax_lines,omitempty"`
+	TotalWeight            int                    `json:"total_weight,omitempty"`
+	FinancialStatus        orderFinancialStatus   `json:"financial_status,omitempty"`
+	Fulfillments           []Fulfillment          `json:"fulfillments,omitempty"`
+	FulfillmentStatus      orderFulfillmentStatus `json:"fulfillment_status,omitempty"`
+	Token                  string                 `json:"token,omitempty"`
+	CartToken              string                 `json:"cart_token,omitempty"`
+	Number                 int                    `json:"number,omitempty"`
+	OrderNumber            int                    `json:"order_number,omitempty"`
+	Note                   string                 `json:"note,omitempty"`
+	Test                   bool                   `json:"test,omitempty"`
+	BrowserIp              string                 `json:"browser_ip,omitempty"`
+	BuyerAcceptsMarketing  bool                   `json:"buyer_accepts_marketing,omitempty"`
+	CancelReason           orderCancelReason      `json:"cancel_reason,omitempty"`
+	NoteAttributes         []NoteAttribute        `json:"note_attributes,omitempty"`
+	DiscountCodes          []DiscountCode         `json:"discount_codes,omitempty"`
+	LineItems              []LineItem             `json:"line_items,omitempty"`
+	ShippingLines          []ShippingLines        `json:"shipping_lines,omitempty"`
+	Transactions           []Transaction          `json:"transactions,omitempty"`
+	AppID                  int                    `json:"app_id,omitempty"`
+	CustomerLocale         string                 `json:"customer_locale,omitempty"`
+	LandingSite            string                 `json:"landing_site,omitempty"`
+	ReferringSite          string                 `json:"referring_site,omitempty"`
+	SourceName             string                 `json:"source_name,omitempty"`
+	ClientDetails          *ClientDetails         `json:"client_details,omitempty"`
+	Tags                   string                 `json:"tags,omitempty"`
+	LocationId             int64                  `json:"location_id,omitempty"`
+	PaymentGatewayNames    []string               `json:"payment_gateway_names,omitempty"`
+	ProcessingMethod       string                 `json:"processing_method,omitempty"`
+	Refunds                []Refund               `json:"refunds,omitempty"`
+	UserId                 int64                  `json:"user_id,omitempty"`
+	OrderStatusUrl         string                 `json:"order_status_url,omitempty"`
+	Gateway                string                 `json:"gateway,omitempty"`
+	Confirmed              bool                   `json:"confirmed,omitempty"`
+	TotalPriceUSD          *decimal.Decimal       `json:"total_price_usd,omitempty"`
+	CheckoutToken          string                 `json:"checkout_token,omitempty"`
+	Reference              string                 `json:"reference,omitempty"`
+	SourceIdentifier       string                 `json:"source_identifier,omitempty"`
+	SourceURL              string                 `json:"source_url,omitempty"`
+	DeviceID               int64                  `json:"device_id,omitempty"`
+	Phone                  string                 `json:"phone,omitempty"`
+	LandingSiteRef         string                 `json:"landing_site_ref,omitempty"`
+	CheckoutID             int64                  `json:"checkout_id,omitempty"`
+	ContactEmail           string                 `json:"contact_email,omitempty"`
+	Metafields             []Metafield            `json:"metafields,omitempty"`
+	SendReceipt            bool                   `json:"send_receipt,omitempty"`
+	SendFulfillmentReceipt bool                   `json:"send_fulfillment_receipt,omitempty"`
 }
 
 type Address struct {
@@ -177,33 +270,33 @@ type DiscountCode struct {
 }
 
 type LineItem struct {
-	ID                         int64                 `json:"id,omitempty"`
-	ProductID                  int64                 `json:"product_id,omitempty"`
-	VariantID                  int64                 `json:"variant_id,omitempty"`
-	Quantity                   int                   `json:"quantity,omitempty"`
-	Price                      *decimal.Decimal      `json:"price,omitempty"`
-	TotalDiscount              *decimal.Decimal      `json:"total_discount,omitempty"`
-	Title                      string                `json:"title,omitempty"`
-	VariantTitle               string                `json:"variant_title,omitempty"`
-	Name                       string                `json:"name,omitempty"`
-	SKU                        string                `json:"sku,omitempty"`
-	Vendor                     string                `json:"vendor,omitempty"`
-	GiftCard                   bool                  `json:"gift_card,omitempty"`
-	Taxable                    bool                  `json:"taxable,omitempty"`
-	FulfillmentService         string                `json:"fulfillment_service,omitempty"`
-	RequiresShipping           bool                  `json:"requires_shipping,omitempty"`
-	VariantInventoryManagement string                `json:"variant_inventory_management,omitempty"`
-	PreTaxPrice                *decimal.Decimal      `json:"pre_tax_price,omitempty"`
-	Properties                 []NoteAttribute       `json:"properties,omitempty"`
-	ProductExists              bool                  `json:"product_exists,omitempty"`
-	FulfillableQuantity        int                   `json:"fulfillable_quantity,omitempty"`
-	Grams                      int                   `json:"grams,omitempty"`
-	FulfillmentStatus          string                `json:"fulfillment_status,omitempty"`
-	TaxLines                   []TaxLine             `json:"tax_lines,omitempty"`
-	OriginLocation             *Address              `json:"origin_location,omitempty"`
-	DestinationLocation        *Address              `json:"destination_location,omitempty"`
-	AppliedDiscount            *AppliedDiscount      `json:"applied_discount,omitempty"`
-	DiscountAllocations        []DiscountAllocations `json:"discount_allocations,omitempty"`
+	ID                         int64                  `json:"id,omitempty"`
+	ProductID                  int64                  `json:"product_id,omitempty"`
+	VariantID                  int64                  `json:"variant_id,omitempty"`
+	Quantity                   int                    `json:"quantity,omitempty"`
+	Price                      *decimal.Decimal       `json:"price,omitempty"`
+	TotalDiscount              *decimal.Decimal       `json:"total_discount,omitempty"`
+	Title                      string                 `json:"title,omitempty"`
+	VariantTitle               string                 `json:"variant_title,omitempty"`
+	Name                       string                 `json:"name,omitempty"`
+	SKU                        string                 `json:"sku,omitempty"`
+	Vendor                     string                 `json:"vendor,omitempty"`
+	GiftCard                   bool                   `json:"gift_card,omitempty"`
+	Taxable                    bool                   `json:"taxable,omitempty"`
+	FulfillmentService         string                 `json:"fulfillment_service,omitempty"`
+	RequiresShipping           bool                   `json:"requires_shipping,omitempty"`
+	VariantInventoryManagement string                 `json:"variant_inventory_management,omitempty"`
+	PreTaxPrice                *decimal.Decimal       `json:"pre_tax_price,omitempty"`
+	Properties                 []NoteAttribute        `json:"properties,omitempty"`
+	ProductExists              bool                   `json:"product_exists,omitempty"`
+	FulfillableQuantity        int                    `json:"fulfillable_quantity,omitempty"`
+	Grams                      int                    `json:"grams,omitempty"`
+	FulfillmentStatus          orderFulfillmentStatus `json:"fulfillment_status,omitempty"`
+	TaxLines                   []TaxLine              `json:"tax_lines,omitempty"`
+	OriginLocation             *Address               `json:"origin_location,omitempty"`
+	DestinationLocation        *Address               `json:"destination_location,omitempty"`
+	AppliedDiscount            *AppliedDiscount       `json:"applied_discount,omitempty"`
+	DiscountAllocations        []DiscountAllocations  `json:"discount_allocations,omitempty"`
 }
 
 type DiscountAllocations struct {

--- a/order_test.go
+++ b/order_test.go
@@ -256,7 +256,7 @@ func TestOrderListOptions(t *testing.T) {
 			Fields: "id,name",
 		},
 
-		Status: StatusAny,
+		Status: OrderStatusAny,
 	}
 
 	orders, err := client.Order.List(options)
@@ -397,8 +397,8 @@ func TestOrderUpdate(t *testing.T) {
 
 	order := Order{
 		ID:                1,
-		FinancialStatus:   FinancialStatusPaid,
-		FulfillmentStatus: FulfillmentStatusFulfilled,
+		FinancialStatus:   OrderFinancialStatusPaid,
+		FulfillmentStatus: OrderFulfillmentStatusFulfilled,
 	}
 
 	o, err := client.Order.Update(order)
@@ -1221,7 +1221,7 @@ func validLineItem() LineItem {
 		ProductExists:       true,
 		FulfillableQuantity: 1,
 		Grams:               100,
-		FulfillmentStatus:   FulfillmentStatusPartial,
+		FulfillmentStatus:   OrderFulfillmentStatusPartial,
 		TaxLines: []TaxLine{
 			TaxLine{
 				Title: "State tax",

--- a/order_test.go
+++ b/order_test.go
@@ -553,7 +553,7 @@ func TestOrderCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "MetafieldTypeSingleLineTextField_text_field",
+		Type:      MetafieldTypeSingleLineTextField,
 		Namespace: "affiliates",
 	}
 
@@ -576,7 +576,7 @@ func TestOrderUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "MetafieldTypeSingleLineTextField_text_field",
+		Type:      MetafieldTypeSingleLineTextField,
 		Namespace: "affiliates",
 	}
 

--- a/order_test.go
+++ b/order_test.go
@@ -256,7 +256,7 @@ func TestOrderListOptions(t *testing.T) {
 			Fields: "id,name",
 		},
 
-		Status: "any",
+		Status: StatusAny,
 	}
 
 	orders, err := client.Order.List(options)
@@ -397,8 +397,8 @@ func TestOrderUpdate(t *testing.T) {
 
 	order := Order{
 		ID:                1,
-		FinancialStatus:   "paid",
-		FulfillmentStatus: "fulfilled",
+		FinancialStatus:   FinancialStatusPaid,
+		FulfillmentStatus: FulfillmentStatusFulfilled,
 	}
 
 	o, err := client.Order.Update(order)
@@ -553,7 +553,7 @@ func TestOrderCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "single_line_text_field",
+		Type:      "MetafieldTypeSingleLineTextField_text_field",
 		Namespace: "affiliates",
 	}
 
@@ -576,7 +576,7 @@ func TestOrderUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "single_line_text_field",
+		Type:      "MetafieldTypeSingleLineTextField_text_field",
 		Namespace: "affiliates",
 	}
 
@@ -1221,7 +1221,7 @@ func validLineItem() LineItem {
 		ProductExists:       true,
 		FulfillableQuantity: 1,
 		Grams:               100,
-		FulfillmentStatus:   "partial",
+		FulfillmentStatus:   FulfillmentStatusPartial,
 		TaxLines: []TaxLine{
 			TaxLine{
 				Title: "State tax",

--- a/page_test.go
+++ b/page_test.go
@@ -223,7 +223,7 @@ func TestPageCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "MetafieldTypeSingleLineTextField_text_field",
+		Type:      MetafieldTypeSingleLineTextField,
 		Namespace: "affiliates",
 	}
 
@@ -246,7 +246,7 @@ func TestPageUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "MetafieldTypeSingleLineTextField_text_field",
+		Type:      MetafieldTypeSingleLineTextField,
 		Namespace: "affiliates",
 	}
 

--- a/page_test.go
+++ b/page_test.go
@@ -223,7 +223,7 @@ func TestPageCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "single_line_text_field",
+		Type:      "MetafieldTypeSingleLineTextField_text_field",
 		Namespace: "affiliates",
 	}
 
@@ -246,7 +246,7 @@ func TestPageUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "single_line_text_field",
+		Type:      "MetafieldTypeSingleLineTextField_text_field",
 		Namespace: "affiliates",
 	}
 

--- a/product.go
+++ b/product.go
@@ -34,6 +34,24 @@ type ProductServiceOp struct {
 	client *Client
 }
 
+type productStatus string
+
+// https://shopify.dev/docs/api/admin-rest/2023-07/resources/product#resource-object
+const (
+	//The product is ready to sell and is available to customers on the online store,
+	//sales channels, and apps. By default, existing products are set to active.
+	ProductStatusActive productStatus = "active"
+
+	//The product is no longer being sold and isn't available to customers on sales
+	//channels and apps.
+	ProductStatusArchived productStatus = "archived"
+
+	//The product isn't ready to sell and is unavailable to customers on sales
+	//channels and apps. By default, duplicated and unarchived products are set to
+	//draft.
+	ProductStatucDraft productStatus = "draft"
+)
+
 // Product represents a Shopify product
 type Product struct {
 	ID                             int64           `json:"id,omitempty"`
@@ -47,7 +65,7 @@ type Product struct {
 	PublishedAt                    *time.Time      `json:"published_at,omitempty"`
 	PublishedScope                 string          `json:"published_scope,omitempty"`
 	Tags                           string          `json:"tags,omitempty"`
-	Status                         string          `json:"status,omitempty"`
+	Status                         productStatus   `json:"status,omitempty"`
 	Options                        []ProductOption `json:"options,omitempty"`
 	Variants                       []Variant       `json:"variants,omitempty"`
 	Image                          Image           `json:"image,omitempty"`

--- a/product_test.go
+++ b/product_test.go
@@ -392,7 +392,7 @@ func TestProductCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "single_line_text_field",
+		Type:      "MetafieldTypeSingleLineTextField_text_field",
 		Namespace: "affiliates",
 	}
 
@@ -415,7 +415,7 @@ func TestProductUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "single_line_text_field",
+		Type:      "MetafieldTypeSingleLineTextField_text_field",
 		Namespace: "affiliates",
 	}
 

--- a/product_test.go
+++ b/product_test.go
@@ -392,7 +392,7 @@ func TestProductCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "MetafieldTypeSingleLineTextField_text_field",
+		Type:      MetafieldTypeSingleLineTextField,
 		Namespace: "affiliates",
 	}
 
@@ -415,7 +415,7 @@ func TestProductUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "MetafieldTypeSingleLineTextField_text_field",
+		Type:      MetafieldTypeSingleLineTextField,
 		Namespace: "affiliates",
 	}
 

--- a/smartcollection_test.go
+++ b/smartcollection_test.go
@@ -240,7 +240,7 @@ func TestSmartCollectionCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "MetafieldTypeSingleLineTextField_text_field",
+		Type:      MetafieldTypeSingleLineTextField,
 		Namespace: "affiliates",
 	}
 
@@ -263,7 +263,7 @@ func TestSmartCollectionUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "MetafieldTypeSingleLineTextField_text_field",
+		Type:      MetafieldTypeSingleLineTextField,
 		Namespace: "affiliates",
 	}
 

--- a/smartcollection_test.go
+++ b/smartcollection_test.go
@@ -240,7 +240,7 @@ func TestSmartCollectionCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "single_line_text_field",
+		Type:      "MetafieldTypeSingleLineTextField_text_field",
 		Namespace: "affiliates",
 	}
 
@@ -263,7 +263,7 @@ func TestSmartCollectionUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "single_line_text_field",
+		Type:      "MetafieldTypeSingleLineTextField_text_field",
 		Namespace: "affiliates",
 	}
 

--- a/variant.go
+++ b/variant.go
@@ -31,36 +31,49 @@ type VariantServiceOp struct {
 	client *Client
 }
 
+type variantInventoryPolicy string
+
+// https://shopify.dev/docs/api/admin-rest/2023-07/resources/product-variant#resource-object
+const (
+	//Customers are not allowed to place orders for the product variant if it's out
+	//of stock. This is the default value.
+	VariantInventoryPolicyDeny variantInventoryPolicy = "deny"
+
+	//Customers are allowed to place orders for the product variant if it's out of
+	//stock.
+	VariantInventoryPolicyContinue variantInventoryPolicy = "continue"
+)
+
 // Variant represents a Shopify variant
 type Variant struct {
-	ID                   int64            `json:"id,omitempty"`
-	ProductID            int64            `json:"product_id,omitempty"`
-	Title                string           `json:"title,omitempty"`
-	Sku                  string           `json:"sku,omitempty"`
-	Position             int              `json:"position,omitempty"`
-	Grams                int              `json:"grams,omitempty"`
-	InventoryPolicy      string           `json:"inventory_policy,omitempty"`
-	Price                *decimal.Decimal `json:"price,omitempty"`
-	CompareAtPrice       *decimal.Decimal `json:"compare_at_price,omitempty"`
-	FulfillmentService   string           `json:"fulfillment_service,omitempty"`
-	InventoryManagement  string           `json:"inventory_management,omitempty"`
-	InventoryItemId      int64            `json:"inventory_item_id,omitempty"`
-	Option1              string           `json:"option1,omitempty"`
-	Option2              string           `json:"option2,omitempty"`
-	Option3              string           `json:"option3,omitempty"`
-	CreatedAt            *time.Time       `json:"created_at,omitempty"`
-	UpdatedAt            *time.Time       `json:"updated_at,omitempty"`
-	Taxable              bool             `json:"taxable,omitempty"`
-	TaxCode              string           `json:"tax_code,omitempty"`
-	Barcode              string           `json:"barcode,omitempty"`
-	ImageID              int64            `json:"image_id,omitempty"`
-	InventoryQuantity    int              `json:"inventory_quantity,omitempty"`
-	Weight               *decimal.Decimal `json:"weight,omitempty"`
-	WeightUnit           string           `json:"weight_unit,omitempty"`
-	OldInventoryQuantity int              `json:"old_inventory_quantity,omitempty"`
-	RequireShipping      bool             `json:"requires_shipping"`
-	AdminGraphqlAPIID    string           `json:"admin_graphql_api_id,omitempty"`
-	Metafields           []Metafield      `json:"metafields,omitempty"`
+	ID                   int64                  `json:"id,omitempty"`
+	ProductID            int64                  `json:"product_id,omitempty"`
+	Title                string                 `json:"title,omitempty"`
+	Sku                  string                 `json:"sku,omitempty"`
+	Position             int                    `json:"position,omitempty"`
+	Grams                int                    `json:"grams,omitempty"`
+	InventoryPolicy      variantInventoryPolicy `json:"inventory_policy,omitempty"`
+	Price                *decimal.Decimal       `json:"price,omitempty"`
+	CompareAtPrice       *decimal.Decimal       `json:"compare_at_price,omitempty"`
+	FulfillmentService   string                 `json:"fulfillment_service,omitempty"`
+	InventoryManagement  string                 `json:"inventory_management,omitempty"`
+	InventoryItemId      int64                  `json:"inventory_item_id,omitempty"`
+	Option1              string                 `json:"option1,omitempty"`
+	Option2              string                 `json:"option2,omitempty"`
+	Option3              string                 `json:"option3,omitempty"`
+	CreatedAt            *time.Time             `json:"created_at,omitempty"`
+	UpdatedAt            *time.Time             `json:"updated_at,omitempty"`
+	Taxable              bool                   `json:"taxable,omitempty"`
+	TaxCode              string                 `json:"tax_code,omitempty"`
+	Barcode              string                 `json:"barcode,omitempty"`
+	ImageID              int64                  `json:"image_id,omitempty"`
+	InventoryQuantity    int                    `json:"inventory_quantity,omitempty"`
+	Weight               *decimal.Decimal       `json:"weight,omitempty"`
+	WeightUnit           string                 `json:"weight_unit,omitempty"`
+	OldInventoryQuantity int                    `json:"old_inventory_quantity,omitempty"`
+	RequireShipping      bool                   `json:"requires_shipping"`
+	AdminGraphqlAPIID    string                 `json:"admin_graphql_api_id,omitempty"`
+	Metafields           []Metafield            `json:"metafields,omitempty"`
 }
 
 // VariantResource represents the result from the variants/X.json endpoint

--- a/variant_test.go
+++ b/variant_test.go
@@ -320,7 +320,7 @@ func TestVariantCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "MetafieldTypeSingleLineTextField_text_field",
+		Type:      MetafieldTypeSingleLineTextField,
 		Namespace: "affiliates",
 	}
 
@@ -343,7 +343,7 @@ func TestVariantUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "MetafieldTypeSingleLineTextField_text_field",
+		Type:      MetafieldTypeSingleLineTextField,
 		Namespace: "affiliates",
 	}
 

--- a/variant_test.go
+++ b/variant_test.go
@@ -320,7 +320,7 @@ func TestVariantCreateMetafield(t *testing.T) {
 	metafield := Metafield{
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "single_line_text_field",
+		Type:      "MetafieldTypeSingleLineTextField_text_field",
 		Namespace: "affiliates",
 	}
 
@@ -343,7 +343,7 @@ func TestVariantUpdateMetafield(t *testing.T) {
 		ID:        2,
 		Key:       "app_key",
 		Value:     "app_value",
-		Type:      "single_line_text_field",
+		Type:      "MetafieldTypeSingleLineTextField_text_field",
 		Namespace: "affiliates",
 	}
 


### PR DESCRIPTION
Define types and constants for well-defined field values to aid in code editor type checking and auto-completion and in reducing back-and-forth between code and Shopify docs to check acceptable values.  Since Shopify limits the values certain fields can accept, this library should do so as well!

Shopify defines acceptable values for certain fields.  This defines those values, and an associated type, so that users are less likely to provide an unacceptable value.  Code editors may even provide a list of acceptable values for a field for auto-completion.  This is really just a code-writing improvement to prevent having to look up the acceptable values for a field in the Shopify API docs.

This should not break any existing code since the new types are all strings and string values, in existing code, will still be accepted.