### PR TITLE
Fix some linting warnings (plus future use of staticcheck?)

### DIFF
--- a/asset_test.go
+++ b/asset_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/jarcoal/httpmock"
 )
 
-func assetTests(t *testing.T, asset Asset) {
-	expectedKey := "templates/index.liquid"
-	if asset.Key != expectedKey {
-		t.Errorf("Asset.Key returned %+v, expected %+v", asset.Key, expectedKey)
-	}
-}
+// func assetTests(t *testing.T, asset Asset) {
+// 	expectedKey := "templates/index.liquid"
+// 	if asset.Key != expectedKey {
+// 		t.Errorf("Asset.Key returned %+v, expected %+v", asset.Key, expectedKey)
+// 	}
+// }
 
 func TestAssetList(t *testing.T) {
 	setup()

--- a/asset_test.go
+++ b/asset_test.go
@@ -8,13 +8,6 @@ import (
 	"github.com/jarcoal/httpmock"
 )
 
-// func assetTests(t *testing.T, asset Asset) {
-// 	expectedKey := "templates/index.liquid"
-// 	if asset.Key != expectedKey {
-// 		t.Errorf("Asset.Key returned %+v, expected %+v", asset.Key, expectedKey)
-// 	}
-// }
-
 func TestAssetList(t *testing.T) {
 	setup()
 	defer teardown()

--- a/carrier.go
+++ b/carrier.go
@@ -122,7 +122,7 @@ type ShippingRate struct {
 	TotalPrice decimal.Decimal `json:"total_price"`
 
 	// Whether the customer must provide a phone number at checkout.
-	PhoneRequired bool `json:phone_required,omitempty"`
+	PhoneRequired bool `json:"phone_required,omitempty"`
 
 	// The earliest delivery date for the displayed rate.
 	MinDeliveryDate *time.Time `json:"min_delivery_date"` // "2013-04-12 14:48:45 -0400"

--- a/customer_address.go
+++ b/customer_address.go
@@ -2,8 +2,6 @@ package goshopify
 
 import "fmt"
 
-// const customerAddressResourceName = "customer-addresses"
-
 // CustomerAddressService is an interface for interfacing with the customer address endpoints
 // of the Shopify API.
 // See: https://help.shopify.com/en/api/reference/customers/customer_address

--- a/customer_address.go
+++ b/customer_address.go
@@ -2,7 +2,7 @@ package goshopify
 
 import "fmt"
 
-const customerAddressResourceName = "customer-addresses"
+// const customerAddressResourceName = "customer-addresses"
 
 // CustomerAddressService is an interface for interfacing with the customer address endpoints
 // of the Shopify API.

--- a/draft_order_test.go
+++ b/draft_order_test.go
@@ -73,7 +73,7 @@ func TestDraftOrderCreate(t *testing.T) {
 
 	draftOrder := DraftOrder{
 		LineItems: []LineItem{
-			LineItem{
+			{
 				VariantID: 1,
 				Quantity:  1,
 			},

--- a/goshopify.go
+++ b/goshopify.go
@@ -239,8 +239,8 @@ func (c *Client) NewRequest(method, relPath string, body, options interface{}) (
 // token. The shopName parameter is the shop's myshopify domain,
 // e.g. "theshop.myshopify.com", or simply "theshop"
 // a.NewClient(shopName, token, opts) is equivalent to NewClient(a, shopName, token, opts)
-func (a App) NewClient(shopName, token string, opts ...Option) *Client {
-	return NewClient(a, shopName, token, opts...)
+func (app App) NewClient(shopName, token string, opts ...Option) *Client {
+	return NewClient(app, shopName, token, opts...)
 }
 
 // Returns a new Shopify API client with an already authenticated shopname and

--- a/logger_test.go
+++ b/logger_test.go
@@ -115,7 +115,7 @@ func TestDoGetHeadersDebug(t *testing.T) {
 	client.logResponse(&http.Response{
 		Status:     http.StatusText(http.StatusOK),
 		StatusCode: http.StatusOK,
-		Header: map[string][]string{"X-Request-Id": []string{"00000000-0000-0000-0000-000000000000"}},
+		Header:     map[string][]string{"X-Request-Id": {"00000000-0000-0000-0000-000000000000"}},
 		Body:       ioutil.NopCloser(strings.NewReader("response body")),
 	})
 

--- a/order_test.go
+++ b/order_test.go
@@ -370,7 +370,7 @@ func TestOrderCreate(t *testing.T) {
 
 	order := Order{
 		LineItems: []LineItem{
-			LineItem{
+			{
 				VariantID: 1,
 				Quantity:  1,
 			},
@@ -1173,7 +1173,7 @@ func propertiesEmptyStructLientItem() LineItem {
 func propertiesStructLientItem() LineItem {
 	return LineItem{
 		Properties: []NoteAttribute{
-			NoteAttribute{
+			{
 				Name:  "property 1",
 				Value: float64(3),
 			},
@@ -1209,11 +1209,11 @@ func validLineItem() LineItem {
 		VariantInventoryManagement: "shopify",
 		PreTaxPrice:                &preTaxPrice,
 		Properties: []NoteAttribute{
-			NoteAttribute{
+			{
 				Name:  "note 1",
 				Value: "one",
 			},
-			NoteAttribute{
+			{
 				Name:  "note 2",
 				Value: float64(2),
 			},
@@ -1223,12 +1223,12 @@ func validLineItem() LineItem {
 		Grams:               100,
 		FulfillmentStatus:   OrderFulfillmentStatusPartial,
 		TaxLines: []TaxLine{
-			TaxLine{
+			{
 				Title: "State tax",
 				Price: &tl1Price,
 				Rate:  &tl1Rate,
 			},
-			TaxLine{
+			{
 				Title: "Federal tax",
 				Price: &tl2Price,
 				Rate:  &tl2Rate,

--- a/product_listing.go
+++ b/product_listing.go
@@ -6,7 +6,8 @@ import (
 )
 
 const productListingBasePath = "product_listings"
-const productsListingResourceName = "product_listings"
+
+// const productsListingResourceName = "product_listings"
 
 // ProductListingService is an interface for interfacing with the product listing endpoints
 // of the Shopify API.

--- a/product_listing.go
+++ b/product_listing.go
@@ -7,8 +7,6 @@ import (
 
 const productListingBasePath = "product_listings"
 
-// const productsListingResourceName = "product_listings"
-
 // ProductListingService is an interface for interfacing with the product listing endpoints
 // of the Shopify API.
 // See: https://shopify.dev/docs/admin-api/rest/reference/sales-channels/productlisting


### PR DESCRIPTION
- Comment out unused code.
- Fix incorrect JSON struct tag (missing opening double-quote).
- Remove unneeded type inside slice of type ("redundant type from array, slice, or map composite literal" warning).

---

There are a lot of other warnings shown by `staticcheck` that were not fixed (`staticcheck` isn't in use for this repo).  Most of these warnings are for the checks listed below.  Fixing these is a rather big change, just due to volume of lines changed.   **Whether or not we want to implement `staticcheck` is the question.**

- ST1003 (using Api instead of API in struct field name).
- ST1021 (not starting the documentation of an exported type with it's name.
- ST1020 (not starting the documentation of an exported method or func with the method's name).

Changing field names per warning ST1003 is a breaking change, so is probably best to be avoided (staticcheck.conf would be set to `checks="all", "-ST1003"]`).  Fixes for the other warnings are no issue since these are just a documentation change.

Examples to be fixed...

- abandoned_checkout.go:25:1: comment on exported type AbandonedCheckoutsResource should be of the form "AbandonedCheckoutsResource ..." (with optional leading article) (ST1021) 
- abandoned_checkout.go:85:1: comment on exported method List should be of the form "List ..." (ST1020) 
- blog.go:49:1: comment on exported type BlogResource should be of the form "BlogResource ..." (with optional leading article) (ST1021) 
- carrier.go:75:1: comment on exported type ShippingRateAddress should be of the form "ShippingRateAddress ..." (with optional leading article) (ST1021) 
- carrier.go: 100:1: comment on exported type ShippingRateResponse should be of the form "ShippingRateResponse ..." (with optional leading article) (ST1021) 
- collect.go:39:1: comment on exported type CollectResource should be of the form "CollectResource ..." (with optional leading article) (ST1021) 
- collect.go:44:1: comment on exported type CollectsResource should be of the form "CollectsResource ..." (with optional leading article) (ST1021) 
- collection.go:39:1: comment on exported type CollectionResource should be of the form "CollectionResource ..." (with optional leading article) (ST1021) 
- collection.go:52:1: comment on exported method ListProducts should be of the form "ListProducts ..." (ST1020)