### PR TITLE
Add Metafield accessor to Shop

### DIFF
--- a/shop.go
+++ b/shop.go
@@ -4,11 +4,17 @@ import (
 	"time"
 )
 
+// The shop resource name is empty because it has no resource id
+const shopResourceName = ""
+
 // ShopService is an interface for interfacing with the shop endpoint of the
 // Shopify API.
 // See: https://help.shopify.com/api/reference/shop
 type ShopService interface {
 	Get(options interface{}) (*Shop, error)
+
+	// MetafieldsService used for CustomCollection resource to communicate with Metafields resource
+	MetafieldsService
 }
 
 // ShopServiceOp handles communication with the shop related methods of the
@@ -80,4 +86,40 @@ func (s *ShopServiceOp) Get(options interface{}) (*Shop, error) {
 	resource := new(ShopResource)
 	err := s.client.Get("shop.json", resource, options)
 	return resource.Shop, err
+}
+
+// ListMetafields for a shop
+func (s *ShopServiceOp) ListMetafields(_ int64, options interface{}) ([]Metafield, error) {
+	metafieldService := &MetafieldServiceOp{client: s.client, resource: shopResourceName}
+	return metafieldService.List(options)
+}
+
+// CountMetafields for a shop
+func (s *ShopServiceOp) CountMetafields(_ int64, options interface{}) (int, error) {
+	metafieldService := &MetafieldServiceOp{client: s.client, resource: shopResourceName}
+	return metafieldService.Count(options)
+}
+
+// GetMetafield for a shop
+func (s *ShopServiceOp) GetMetafield(_ int64, metafieldID int64, options interface{}) (*Metafield, error) {
+	metafieldService := &MetafieldServiceOp{client: s.client, resource: shopResourceName}
+	return metafieldService.Get(metafieldID, options)
+}
+
+// CreateMetafield for a shop
+func (s *ShopServiceOp) CreateMetafield(_ int64, metafield Metafield) (*Metafield, error) {
+	metafieldService := &MetafieldServiceOp{client: s.client, resource: shopResourceName}
+	return metafieldService.Create(metafield)
+}
+
+// UpdateMetafield for a shop
+func (s *ShopServiceOp) UpdateMetafield(_ int64, metafield Metafield) (*Metafield, error) {
+	metafieldService := &MetafieldServiceOp{client: s.client, resource: shopResourceName}
+	return metafieldService.Update(metafield)
+}
+
+// DeleteMetafield for a shop
+func (s *ShopServiceOp) DeleteMetafield(_ int64, metafieldID int64) error {
+	metafieldService := &MetafieldServiceOp{client: s.client, resource: shopResourceName}
+	return metafieldService.Delete(metafieldID)
 }

--- a/shop.go
+++ b/shop.go
@@ -13,7 +13,7 @@ const shopResourceName = ""
 type ShopService interface {
 	Get(options interface{}) (*Shop, error)
 
-	// MetafieldsService used for CustomCollection resource to communicate with Metafields resource
+	// MetafieldsService used for Shop resource to communicate with Metafields resource
 	MetafieldsService
 }
 

--- a/shop_test.go
+++ b/shop_test.go
@@ -2,6 +2,7 @@ package goshopify
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -52,5 +53,135 @@ func TestShopGet(t *testing.T) {
 		if c.expected != c.actual {
 			t.Errorf("Shop.%v returned %v, expected %v", c.field, c.actual, c.expected)
 		}
+	}
+}
+
+func TestShopListMetafields(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields.json", client.pathPrefix),
+		httpmock.NewStringResponder(200, `{"metafields": [{"id":1},{"id":2}]}`))
+
+	metafields, err := client.Shop.ListMetafields(1, nil)
+	if err != nil {
+		t.Errorf("Shop.ListMetafields() returned error: %v", err)
+	}
+
+	expected := []Metafield{{ID: 1}, {ID: 2}}
+	if !reflect.DeepEqual(metafields, expected) {
+		t.Errorf("Shop.ListMetafields() returned %+v, expected %+v", metafields, expected)
+	}
+}
+
+func TestShopCountMetafields(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields/count.json", client.pathPrefix),
+		httpmock.NewStringResponder(200, `{"count": 3}`))
+
+	params := map[string]string{"created_at_min": "2016-01-01T00:00:00Z"}
+	httpmock.RegisterResponderWithQuery(
+		"GET",
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields/count.json", client.pathPrefix),
+		params,
+		httpmock.NewStringResponder(200, `{"count": 2}`))
+
+	cnt, err := client.Shop.CountMetafields(1, nil)
+	if err != nil {
+		t.Errorf("Shop.CountMetafields() returned error: %v", err)
+	}
+
+	expected := 3
+	if cnt != expected {
+		t.Errorf("Shop.CountMetafields() returned %d, expected %d", cnt, expected)
+	}
+
+	date := time.Date(2016, time.January, 1, 0, 0, 0, 0, time.UTC)
+	cnt, err = client.Shop.CountMetafields(1, CountOptions{CreatedAtMin: date})
+	if err != nil {
+		t.Errorf("Shop.CountMetafields() returned error: %v", err)
+	}
+
+	expected = 2
+	if cnt != expected {
+		t.Errorf("Shop.CountMetafields() returned %d, expected %d", cnt, expected)
+	}
+}
+
+func TestShopGetMetafield(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields/2.json", client.pathPrefix),
+		httpmock.NewStringResponder(200, `{"metafield": {"id":2}}`))
+
+	metafield, err := client.Shop.GetMetafield(1, 2, nil)
+	if err != nil {
+		t.Errorf("Shop.GetMetafield() returned error: %v", err)
+	}
+
+	expected := &Metafield{ID: 2}
+	if !reflect.DeepEqual(metafield, expected) {
+		t.Errorf("Shop.GetMetafield() returned %+v, expected %+v", metafield, expected)
+	}
+}
+
+func TestShopCreateMetafield(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("POST", fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields.json", client.pathPrefix),
+		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
+
+	metafield := Metafield{
+		Key:       "app_key",
+		Value:     "app_value",
+		Type:      MetafieldTypeSingleLineTextField,
+		Namespace: "affiliates",
+	}
+
+	returnedMetafield, err := client.Shop.CreateMetafield(1, metafield)
+	if err != nil {
+		t.Errorf("Shop.CreateMetafield() returned error: %v", err)
+	}
+
+	MetafieldTests(t, *returnedMetafield)
+}
+
+func TestShopUpdateMetafield(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields/2.json", client.pathPrefix),
+		httpmock.NewBytesResponder(200, loadFixture("metafield.json")))
+
+	metafield := Metafield{
+		ID:        2,
+		Key:       "app_key",
+		Value:     "app_value",
+		Type:      MetafieldTypeSingleLineTextField,
+		Namespace: "affiliates",
+	}
+
+	returnedMetafield, err := client.Shop.UpdateMetafield(1, metafield)
+	if err != nil {
+		t.Errorf("Shop.UpdateMetafield() returned error: %v", err)
+	}
+
+	MetafieldTests(t, *returnedMetafield)
+}
+
+func TestShopDeleteMetafield(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("https://fooshop.myshopify.com/%s/metafields/2.json", client.pathPrefix),
+		httpmock.NewStringResponder(200, "{}"))
+
+	err := client.Shop.DeleteMetafield(1, 2)
+	if err != nil {
+		t.Errorf("Shop.DeleteMetafield() returned error: %v", err)
 	}
 }


### PR DESCRIPTION
This adds an easy way to access the metafields on the shop resource.

In order to reuse the existing interfaces, the methods still accept a resource id, but we just ignore that value

```golang 
metafields, err := client.Shop.ListMetafields(0, nil)
```