### PR TITLE
Add GraphQL endpoint

### DIFF
--- a/carrier.go
+++ b/carrier.go
@@ -122,7 +122,7 @@ type ShippingRate struct {
 	TotalPrice decimal.Decimal `json:"total_price"`
 
 	// Whether the customer must provide a phone number at checkout.
-	PhoneRequired bool `json:phone_required,omitempty"`
+	PhoneRequired bool `json:"phone_required,omitempty"`
 
 	// The earliest delivery date for the displayed rate.
 	MinDeliveryDate *time.Time `json:"min_delivery_date"` // "2013-04-12 14:48:45 -0400"

--- a/goshopify.go
+++ b/goshopify.go
@@ -50,6 +50,7 @@ type App struct {
 type RateLimitInfo struct {
 	RequestCount      int
 	BucketSize        int
+	GraphQLCost       *GraphQLCost
 	RetryAfterSeconds float64
 }
 
@@ -122,6 +123,7 @@ type Client struct {
 	CarrierService             CarrierServiceService
 	Payouts                    PayoutsService
 	GiftCard                   GiftCardService
+	GraphQL                    GraphQLService
 }
 
 // A general response error that follows a similar layout to Shopify's response
@@ -303,6 +305,7 @@ func NewClient(app App, shopName, token string, opts ...Option) *Client {
 	c.CarrierService = &CarrierServiceOp{client: c}
 	c.Payouts = &PayoutsServiceOp{client: c}
 	c.GiftCard = &GiftCardServiceOp{client: c}
+	c.GraphQL = &GraphQLServiceOp{client: c}
 
 	// apply any options
 	for _, opt := range opts {

--- a/graphql.go
+++ b/graphql.go
@@ -1,0 +1,148 @@
+package goshopify
+
+import (
+	"time"
+)
+
+// GraphQLService is an interface to interact with the graphql endpoint
+// of the Shopify API
+// See https://shopify.dev/docs/admin-api/graphql/reference
+type GraphQLService interface {
+	Query(string, interface{}, interface{}) error
+}
+
+// GraphQLServiceOp handles communication with the graphql endpoint of
+// the Shopify API.
+type GraphQLServiceOp struct {
+	client *Client
+}
+
+type graphQLResponse struct {
+	Data       interface{}       `json:"data"`
+	Errors     []graphQLError    `json:"errors"`
+	Extensions *graphQLExtension `json:"extensions"`
+}
+
+type graphQLExtension struct {
+	Cost GraphQLCost `json:"cost"`
+}
+
+// GraphQLCost represents the cost of the graphql query
+type GraphQLCost struct {
+	RequestedQueryCost int                   `json:"requestedQueryCost"`
+	ActualQueryCost    *int                  `json:"actualQueryCost"`
+	ThrottleStatus     GraphQLThrottleStatus `json:"throttleStatus"`
+}
+
+// GraphQLThrottleStatus represents the status of the shop's rate limit points
+type GraphQLThrottleStatus struct {
+	MaximumAvailable   float64 `json:"maximumAvailable"`
+	CurrentlyAvailable float64 `json:"currentlyAvailable"`
+	RestoreRate        float64 `json:"restoreRate"`
+}
+
+type graphQLError struct {
+	Message    string                 `json:"message"`
+	Extensions *graphQLErrorExtension `json:"extensions"`
+	Locations  []graphQLErrorLocation `json:"locations"`
+}
+
+type graphQLErrorExtension struct {
+	Code          string
+	Documentation string
+}
+
+const (
+	graphQLErrorCodeThrottled = "THROTTLED"
+)
+
+type graphQLErrorLocation struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}
+
+// Query creates a graphql query against the Shopify API
+// the "data" portion of the response is unmarshalled into resp
+func (s *GraphQLServiceOp) Query(q string, vars, resp interface{}) error {
+	data := struct {
+		Query     string      `json:"query"`
+		Variables interface{} `json:"variables"`
+	}{
+		Query:     q,
+		Variables: vars,
+	}
+
+	attempts := 0
+
+	for {
+		gr := graphQLResponse{
+			Data: resp,
+		}
+
+		err := s.client.Post("graphql.json", data, &gr)
+		// internal attempts count towards outer total
+		attempts += s.client.attempts
+		s.client.attempts = attempts
+
+		var ra float64
+
+		if gr.Extensions != nil {
+			ra = gr.Extensions.Cost.RetryAfterSeconds()
+			s.client.RateLimits.GraphQLCost = &gr.Extensions.Cost
+			s.client.RateLimits.RetryAfterSeconds = ra
+		}
+
+		if len(gr.Errors) > 0 {
+			re := ResponseError{Status: 200}
+			var doRetry bool
+
+			for _, err := range gr.Errors {
+				if err.Extensions != nil && err.Extensions.Code == graphQLErrorCodeThrottled {
+					if attempts >= s.client.retries {
+						return RateLimitError{
+							RetryAfter: int(ra),
+							ResponseError: ResponseError{
+								Status:  200,
+								Message: err.Message,
+							},
+						}
+					}
+
+					// only need to retry graphql throttled retries
+					doRetry = true
+				}
+
+				re.Errors = append(re.Errors, err.Message)
+			}
+
+			if doRetry {
+				wait := time.Duration(ra) * time.Second
+				s.client.log.Debugf("rate limited waiting %s", wait.String())
+				time.Sleep(wait)
+				continue
+			}
+
+			err = re
+		}
+
+		return err
+	}
+}
+
+// RetryAfterSeconds returns the estimated retry after seconds based on
+// the requested query cost and throttle status
+func (c GraphQLCost) RetryAfterSeconds() float64 {
+	var diff float64
+
+	if c.ActualQueryCost != nil {
+		diff = c.ThrottleStatus.CurrentlyAvailable - float64(*c.ActualQueryCost)
+	} else {
+		diff = c.ThrottleStatus.CurrentlyAvailable - float64(c.RequestedQueryCost)
+	}
+
+	if diff < 0 {
+		return -diff / c.ThrottleStatus.RestoreRate
+	}
+
+	return 0
+}

--- a/graphql.go
+++ b/graphql.go
@@ -81,8 +81,9 @@ func (s *GraphQLServiceOp) Query(q string, vars, resp interface{}) error {
 		}
 
 		err := s.client.Post("graphql.json", data, &gr)
+
 		// internal attempts count towards outer total
-		attempts += s.client.attempts
+		attempts += 1
 
 		var retryAfterSecs float64
 

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -1,0 +1,367 @@
+package goshopify
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+)
+
+func TestGraphQLQuery(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder(
+		"POST",
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/graphql.json", client.pathPrefix),
+		httpmock.NewStringResponder(200, `{"data":{"foo":"bar"}}`),
+	)
+
+	resp := struct {
+		Foo string `json:"foo"`
+	}{}
+	err := client.GraphQL.Query("query {}", nil, &resp)
+
+	if err != nil {
+		t.Errorf("GraphQL.Query returned error: %v", err)
+	}
+
+	expectedFoo := "bar"
+	if resp.Foo != expectedFoo {
+		t.Errorf("resp.Foo returned %s expected %s", resp.Foo, expectedFoo)
+	}
+}
+
+func TestGraphQLQueryWithError(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder(
+		"POST",
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/graphql.json", client.pathPrefix),
+		httpmock.NewStringResponder(200, `{"errors":[{"message":"oops"}]}`),
+	)
+
+	resp := struct {
+		Foo string `json:"foo"`
+	}{}
+	err := client.GraphQL.Query("query {}", nil, &resp)
+
+	if err == nil {
+		t.Error("GraphQL.Query should return error!")
+	}
+
+	expectedError := "oops"
+	if err.Error() != expectedError {
+		t.Errorf("GraphQL.Query returned error message %s but expected %s", err.Error(), expectedError)
+	}
+}
+
+func TestGraphQLQueryWithRetries(t *testing.T) {
+	setup()
+	defer teardown()
+
+	type MyStruct struct {
+		Foo string `json:"foo"`
+	}
+
+	var retries int
+
+	cases := []struct {
+		description string
+		responder   httpmock.Responder
+		expected    interface{}
+		retries     int
+	}{
+		{
+			description: "no retries",
+			responder: func(req *http.Request) (*http.Response, error) {
+				return httpmock.NewStringResponse(200, `{"data":{"foo":"bar"}}`), nil
+			},
+			expected: MyStruct{Foo: "bar"},
+			retries:  1,
+		},
+		{
+			description: "3 throttled retries",
+			responder: func(req *http.Request) (*http.Response, error) {
+				return httpmock.NewStringResponse(200, `
+					{
+						"errors":[{"message":"Throttled","extensions":{"code":"THROTTLED"}}],
+						"extensions":{
+							"cost":{
+								"requestedQueryCost":400,
+								"throttleStatus":{
+									"maximumAvailable":1000.0,
+									"currentlyAvailable":300,
+									"restoreRate":50.0
+								}
+							}
+						}
+					}`), nil
+			},
+			expected: RateLimitError{
+				ResponseError: ResponseError{
+					Status:  200,
+					Message: "Throttled",
+				},
+				RetryAfter: 2,
+			},
+			retries: maxRetries,
+		},
+		{
+			description: "2 throttled then success",
+			responder: func(req *http.Request) (*http.Response, error) {
+				if retries > 1 {
+					retries--
+					return httpmock.NewStringResponse(200, `
+					{
+						"errors":[{"message":"Throttled","extensions":{"code":"THROTTLED"}}],
+						"extensions":{
+							"cost":{
+								"requestedQueryCost":400,
+								"throttleStatus":{
+									"maximumAvailable":1000.0,
+									"currentlyAvailable":300,
+									"restoreRate":50.0
+								}
+							}
+						}
+					}`), nil
+				}
+
+				return httpmock.NewStringResponse(200, `{"data":{"foo":"bar"}}`), nil
+			},
+			expected: MyStruct{Foo: "bar"},
+			retries:  maxRetries,
+		},
+		{
+			description: "1 503, 1 throttled then success",
+			responder: func(req *http.Request) (*http.Response, error) {
+				if retries > 2 {
+					retries--
+					return httpmock.NewStringResponse(http.StatusServiceUnavailable, "<html></html>"), nil
+				}
+
+				if retries > 1 {
+					retries--
+					return httpmock.NewStringResponse(200, `
+					{
+						"errors":[{"message":"Throttled","extensions":{"code":"THROTTLED"}}],
+						"extensions":{
+							"cost":{
+								"requestedQueryCost":400,
+								"throttleStatus":{
+									"maximumAvailable":1000.0,
+									"currentlyAvailable":300,
+									"restoreRate":50.0
+								}
+							}
+						}
+					}`), nil
+				}
+
+				return httpmock.NewStringResponse(200, `{"data":{"foo":"bar"}}`), nil
+			},
+			expected: MyStruct{Foo: "bar"},
+			retries:  maxRetries,
+		},
+
+		{
+			description: "3 503s",
+			responder: func(req *http.Request) (*http.Response, error) {
+				return httpmock.NewStringResponse(http.StatusServiceUnavailable, ""), nil
+			},
+			expected: ResponseError{
+				Status: http.StatusServiceUnavailable,
+			},
+			retries: maxRetries,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			// used to track retries in case clojure
+			retries = c.retries
+
+			httpmock.RegisterResponder(
+				"POST",
+				fmt.Sprintf("https://fooshop.myshopify.com/%s/graphql.json", client.pathPrefix),
+				c.responder,
+			)
+
+			resp := MyStruct{}
+			err := client.GraphQL.Query("query {}", nil, &resp)
+
+			if client.attempts != c.retries {
+				t.Errorf("GraphQL.Query attempts equal %d but expected %d", client.attempts, c.retries)
+			}
+
+			if err != nil {
+				if !reflect.DeepEqual(err, c.expected) {
+					t.Errorf("GraphQL.Query got error %#v but expected %#v", err, c.expected)
+				}
+			} else if !reflect.DeepEqual(resp, c.expected) {
+				t.Errorf("GraphQL.Query responsed %#v but expected %#v", resp, c.expected)
+			}
+		})
+	}
+}
+
+func TestGraphQLQueryWithMultipleErrors(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder(
+		"POST",
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/graphql.json", client.pathPrefix),
+		httpmock.NewStringResponder(200, `{"errors":[{"message":"oops"},{"message":"I did it again"}]}`),
+	)
+
+	resp := struct {
+		Foo string `json:"foo"`
+	}{}
+	err := client.GraphQL.Query("query {}", nil, &resp)
+
+	if err == nil {
+		t.Error("GraphQL.Query should return error!")
+	}
+
+	expectedError := "I did it again, oops"
+	if err.Error() != expectedError {
+		t.Errorf("GraphQL.Query returned error message %s but expected %s", err.Error(), expectedError)
+	}
+}
+
+func TestGraphQLQueryWithThrottledError(t *testing.T) {
+	setup()
+	defer teardown()
+	client.retries = 1
+
+	httpmock.RegisterResponder(
+		"POST",
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/graphql.json", client.pathPrefix),
+		httpmock.NewStringResponder(200, `
+			{
+				"errors":[{"message":"Throttled","extensions":{"code":"THROTTLED"}}],
+				"extensions":{
+					"cost":{
+						"requestedQueryCost":400,
+						"throttleStatus":{
+							"maximumAvailable":1000.0,
+							"currentlyAvailable":300,
+							"restoreRate":50.0
+						}
+					}
+				}
+			}`),
+	)
+
+	resp := struct {
+		Foo string `json:"foo"`
+	}{}
+	err := client.GraphQL.Query("query {}", nil, &resp)
+
+	if err == nil {
+		t.Error("GraphQL.Query should return error!")
+	}
+
+	expectedError := "Throttled"
+	if err.Error() != expectedError {
+		t.Errorf("GraphQL.Query returned error message %s but expected %s", err.Error(), expectedError)
+	}
+
+	rle, ok := err.(RateLimitError)
+	if !ok {
+		t.Errorf("GraphQL.Query returned error not of type RateLimitError")
+	}
+
+	expectedRetryAfterSeconds := 2.0
+	if rle.RetryAfter != int(expectedRetryAfterSeconds) {
+		t.Errorf("GraphQL.Query rle.RetryAfter is %d but expected %d", rle.RetryAfter, int(expectedRetryAfterSeconds))
+	}
+
+	if client.RateLimits.GraphQLCost == nil {
+		t.Errorf("GraphQL.Query should have assigned client.RateLimits.GraphQLCost")
+	}
+
+	if client.RateLimits.RetryAfterSeconds != expectedRetryAfterSeconds {
+		t.Errorf("GraphQL.Query client.RateLimits.RetryAfterSeconds is %f but expected %f", client.RateLimits.RetryAfterSeconds, expectedRetryAfterSeconds)
+	}
+}
+
+func TestGraphQLCostRetryAfterSeconds(t *testing.T) {
+	cases := []struct {
+		description string
+		GraphQLCost GraphQLCost
+		expected    float64
+	}{
+		{
+			"last query passed, does not need to be throttled",
+			GraphQLCost{
+				RequestedQueryCost: 300,
+				ActualQueryCost:    makeIntPointer(50),
+				ThrottleStatus: GraphQLThrottleStatus{
+					MaximumAvailable:   1000,
+					CurrentlyAvailable: 400,
+					RestoreRate:        50,
+				},
+			},
+			0,
+		},
+		{
+			"last query failed, needs to be throttled",
+			GraphQLCost{
+				RequestedQueryCost: 300,
+				ActualQueryCost:    nil,
+				ThrottleStatus: GraphQLThrottleStatus{
+					MaximumAvailable:   1000,
+					CurrentlyAvailable: 200,
+					RestoreRate:        50,
+				},
+			},
+			2,
+		},
+		{
+			"last query passed, does not need to be throttled",
+			GraphQLCost{
+				RequestedQueryCost: 300,
+				ActualQueryCost:    makeIntPointer(50),
+				ThrottleStatus: GraphQLThrottleStatus{
+					MaximumAvailable:   1000,
+					CurrentlyAvailable: 200,
+					RestoreRate:        50,
+				},
+			},
+			0,
+		},
+		{
+			"last query passed, needs to be throttled",
+			GraphQLCost{
+				RequestedQueryCost: 300,
+				ActualQueryCost:    makeIntPointer(100),
+				ThrottleStatus: GraphQLThrottleStatus{
+					MaximumAvailable:   1000,
+					CurrentlyAvailable: 50,
+					RestoreRate:        50,
+				},
+			},
+			1,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			s := c.GraphQLCost.RetryAfterSeconds()
+
+			if s != c.expected {
+				t.Errorf("GraphQLCost.RetryAfterSeconds returned %f expected %f (%s)", s, c.expected, c.description)
+			}
+		})
+	}
+}
+
+func makeIntPointer(v int) *int {
+	return &v
+}

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -198,11 +198,7 @@ func TestGraphQLQueryWithRetries(t *testing.T) {
 
 			callCountInfo := httpmock.GetCallCountInfo()
 
-			attempts, ok := callCountInfo[fmt.Sprintf("POST %s", requestURL)]
-
-			if !ok {
-				attempts = 0
-			}
+			attempts := callCountInfo[fmt.Sprintf("POST %s", requestURL)]
 
 			if attempts != c.retries {
 				t.Errorf("GraphQL.Query attempts equal %d but expected %d", attempts, c.retries)

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -22,7 +22,7 @@ func TestGraphQLQuery(t *testing.T) {
 	resp := struct {
 		Foo string `json:"foo"`
 	}{}
-	err := client.GraphQL.Query("query {}", nil, &resp)
+	_, err := client.GraphQL.Query("query {}", nil, &resp)
 
 	if err != nil {
 		t.Errorf("GraphQL.Query returned error: %v", err)
@@ -47,7 +47,7 @@ func TestGraphQLQueryWithError(t *testing.T) {
 	resp := struct {
 		Foo string `json:"foo"`
 	}{}
-	err := client.GraphQL.Query("query {}", nil, &resp)
+	_, err := client.GraphQL.Query("query {}", nil, &resp)
 
 	if err == nil {
 		t.Error("GraphQL.Query should return error!")
@@ -192,10 +192,10 @@ func TestGraphQLQueryWithRetries(t *testing.T) {
 			)
 
 			resp := MyStruct{}
-			err := client.GraphQL.Query("query {}", nil, &resp)
+			attempts, err := client.GraphQL.Query("query {}", nil, &resp)
 
-			if client.attempts != c.retries {
-				t.Errorf("GraphQL.Query attempts equal %d but expected %d", client.attempts, c.retries)
+			if attempts != c.retries {
+				t.Errorf("GraphQL.Query attempts equal %d but expected %d", attempts, c.retries)
 			}
 
 			if err != nil {
@@ -222,7 +222,7 @@ func TestGraphQLQueryWithMultipleErrors(t *testing.T) {
 	resp := struct {
 		Foo string `json:"foo"`
 	}{}
-	err := client.GraphQL.Query("query {}", nil, &resp)
+	_, err := client.GraphQL.Query("query {}", nil, &resp)
 
 	if err == nil {
 		t.Error("GraphQL.Query should return error!")
@@ -261,7 +261,7 @@ func TestGraphQLQueryWithThrottledError(t *testing.T) {
 	resp := struct {
 		Foo string `json:"foo"`
 	}{}
-	err := client.GraphQL.Query("query {}", nil, &resp)
+	_, err := client.GraphQL.Query("query {}", nil, &resp)
 
 	if err == nil {
 		t.Error("GraphQL.Query should return error!")

--- a/options.go
+++ b/options.go
@@ -20,7 +20,7 @@ func WithVersion(apiVersion string) Option {
 	}
 }
 
-// WithRetry set the number of times a request will be retried if a rate limit or service unavailable error is returned.
+// WithRetry sets the number of times a request will be retried if a rate limit or service unavailable error is returned.
 // Rate limiting can be either REST API limits or GraphQL Cost limits
 func WithRetry(retries int) Option {
 	return func(c *Client) {

--- a/options.go
+++ b/options.go
@@ -20,6 +20,8 @@ func WithVersion(apiVersion string) Option {
 	}
 }
 
+// WithRetry set the number of times a request will be retried if a rate limit or service unavailable error is returned.
+// Rate limiting can be either REST API limits or GraphQL Cost limits
 func WithRetry(retries int) Option {
 	return func(c *Client) {
 		c.retries = retries


### PR DESCRIPTION
This is a re-introduction of an old PR by another person, trimmed down to just the GraphQL Client and a typo-fix
https://github.com/bold-commerce/go-shopify/pull/118

I'm not sure why the original one got closed, but I've succeessfully used it for making mutations with queries

```golang
	req := `mutation webPixelCreate($webPixel: WebPixelInput!) {
		webPixelCreate(webPixel: $webPixel) {
			userErrors {
				code
				field
				message
			}
			webPixel {
				settings
				id
			}
		}
	}`

	settings, err := json.Marshal(map[string]interface{}{
		"accountID": fmt.Sprintf("%d", websiteID),
	})

	if err != nil {
		return err
	}

	variables := map[string]interface{}{
		"webPixel": map[string]interface{}{
			"settings": string(settings),
		},
	}

	var foo struct {
	}

	client.GraphQL.Query(req, &variables, &foo)
```