### PR TITLE
Remove long-term deprecated, and no longer functioning, total_price_usd field

### DIFF
--- a/order.go
+++ b/order.go
@@ -229,7 +229,6 @@ type Order struct {
 	OrderStatusUrl         string                 `json:"order_status_url,omitempty"`
 	Gateway                string                 `json:"gateway,omitempty"`
 	Confirmed              bool                   `json:"confirmed,omitempty"`
-	TotalPriceUSD          *decimal.Decimal       `json:"total_price_usd,omitempty"`
 	CheckoutToken          string                 `json:"checkout_token,omitempty"`
 	Reference              string                 `json:"reference,omitempty"`
 	SourceIdentifier       string                 `json:"source_identifier,omitempty"`
@@ -293,10 +292,15 @@ type LineItem struct {
 	Grams                      int                    `json:"grams,omitempty"`
 	FulfillmentStatus          orderFulfillmentStatus `json:"fulfillment_status,omitempty"`
 	TaxLines                   []TaxLine              `json:"tax_lines,omitempty"`
-	OriginLocation             *Address               `json:"origin_location,omitempty"`
-	DestinationLocation        *Address               `json:"destination_location,omitempty"`
-	AppliedDiscount            *AppliedDiscount       `json:"applied_discount,omitempty"`
-	DiscountAllocations        []DiscountAllocations  `json:"discount_allocations,omitempty"`
+
+	//Deprecated: See 2022-10 release notes: https://shopify.dev/docs/api/release-notes/2022-10
+	OriginLocation *Address `json:"origin_location,omitempty"`
+
+	//Deprecated: See 2022-10 release notes: https://shopify.dev/docs/api/release-notes/2022-10
+	DestinationLocation *Address `json:"destination_location,omitempty"`
+
+	AppliedDiscount     *AppliedDiscount      `json:"applied_discount,omitempty"`
+	DiscountAllocations []DiscountAllocations `json:"discount_allocations,omitempty"`
 }
 
 type DiscountAllocations struct {


### PR DESCRIPTION
The TotalPriceUSD struct field (on the Order type) no longer works.  It was deprecated in Oct. 2022.  See https://shopify.dev/docs/api/release-notes/2022-10#:~:text=resource%20is%20deprecated%3A-,total_price_usd,-Subscription%20billing%20cycles

Also, mark some other fields that are deprecated per the linked Shopify doc as well.  I have not tested to confirm if these fields still exist or not.  Marking these fields as deprecated should inform users when using a code editor that shows hints not to use this field, or to test it more thoroughly.