### PR TITLE
Fixed time parsing FulfilmentOrder

### DIFF
--- a/fixtures/fulfillment_order.json
+++ b/fixtures/fulfillment_order.json
@@ -21,8 +21,8 @@
       "min_delivery_date_time": "2022-04-20T23:59:59-04:00",
       "max_delivery_date_time": "2022-04-28T23:59:59-04:00"
     },
-    "fulfill_at": "2021-01-01",
-    "fulfill_by": "2021-01-01",
+    "fulfill_at": "2021-01-01T07:00:00-04:00",
+    "fulfill_by": "2021-01-01T07:00:00-04:00",
     "fulfillment_holds": [
       {
         "reason": "incorrect_address",

--- a/fulfillment_order.go
+++ b/fulfillment_order.go
@@ -124,11 +124,10 @@ type FulfillmentOrder struct {
 	Id                  int64                               `json:"id,omitempty"`
 	AssignedLocation    FulfillmentOrderAssignedLocation    `json:"assigned_location,omitempty"`
 	AssignedLocationId  int64                               `json:"assigned_location_id,omitempty"`
-	CreatedAt           time.Time                           `json:"created_at,omitempty"`
 	DeliveryMethod      FulfillmentOrderDeliveryMethod      `json:"delivery_method,omitempty"`
 	Destination         FulfillmentOrderDestination         `json:"destination,omitempty"`
-	FulfillAt           OnlyDate                            `json:"fulfill_at,omitempty"`
-	FulfillBy           OnlyDate                            `json:"fulfill_by,omitempty"`
+	FulfillAt           *time.Time                          `json:"fulfill_at,omitempty"`
+	FulfillBy           *time.Time                          `json:"fulfill_by,omitempty"`
 	FulfillmentHolds    []FulfillmentOrderHold              `json:"fulfillment_holds,omitempty"`
 	InternationalDuties FulfillmentOrderInternationalDuties `json:"international_duties,omitempty"`
 	LineItems           []FulfillmentOrderLineItem          `json:"line_items,omitempty"`
@@ -138,7 +137,8 @@ type FulfillmentOrder struct {
 	ShopId              int64                               `json:"shop_id,omitempty"`
 	Status              string                              `json:"status,omitempty"`
 	SupportedActions    []string                            `json:"supported_actions,omitempty"`
-	UpdatedAt           time.Time                           `json:"updated_at,omitempty"`
+	CreatedAt           *time.Time                          `json:"created_at,omitempty"`
+	UpdatedAt           *time.Time                          `json:"updated_at,omitempty"`
 }
 
 // FulfillmentOrdersResource represents the result from the fulfilment_orders.json endpoint


### PR DESCRIPTION
I've made the datetime fields (created_at, updated_at, fulfill_at, fulfill_by) consistent between the `FulfilmentOrder` and the `Order` structs. 

I've also replaced the `OnlyDate` struct with `*time.Time` in the `FulfilmentOrder` struct, as the actual REST response from Shopify contains a datetime, not just a date:
![image](https://github.com/bold-commerce/go-shopify/assets/9220754/16397ac6-fff5-4acb-8f80-a4eaf366f5e3)

I've updated this in the fixtures to make the tests pass.