### PR TITLE
feat: add app uninstall functionality

### DIFF
--- a/api_permissions.go
+++ b/api_permissions.go
@@ -1,0 +1,27 @@
+package goshopify
+
+import (
+	"context"
+	"fmt"
+)
+
+const apiPermissionsBasePath = "api_permissions"
+
+// ApiPermissionsService is an interface for interfacing with the API
+// permissions endpoints of the Shopify API.
+// See: https://help.shopify.com/api/reference/theme
+type ApiPermissionsService interface {
+	Delete(context.Context) error
+}
+
+// ApiPermissionsServiceOp handles communication with the theme related methods of
+// the Shopify API.
+type ApiPermissionsServiceOp struct {
+	client *Client
+}
+
+// Uninstall an app.
+func (s *ApiPermissionsServiceOp) Delete(ctx context.Context) error {
+	path := fmt.Sprintf("%s/current.json", apiPermissionsBasePath)
+	return s.client.Delete(ctx, path)
+}

--- a/api_permissions_test.go
+++ b/api_permissions_test.go
@@ -1,0 +1,23 @@
+package goshopify
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+)
+
+func TestApiPermissionsDelete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("DELETE",
+		fmt.Sprintf("https://fooshop.myshopify.com/%s/%s/current.json", client.pathPrefix, apiPermissionsBasePath),
+		httpmock.NewStringResponder(200, ""))
+
+	err := client.ApiPermissions.Delete(context.Background())
+	if err != nil {
+		t.Errorf("Theme.Delete returned error: %v", err)
+	}
+}

--- a/goshopify.go
+++ b/goshopify.go
@@ -130,6 +130,7 @@ type Client struct {
 	FulfillmentRequest         FulfillmentRequestService
 	PaymentsTransactions       PaymentsTransactionsService
 	OrderRisk                  OrderRiskService
+	ApiPermissions             ApiPermissionsService
 }
 
 // A general response error that follows a similar layout to Shopify's response
@@ -334,6 +335,7 @@ func NewClient(app App, shopName, token string, opts ...Option) (*Client, error)
 	c.FulfillmentRequest = &FulfillmentRequestServiceOp{client: c}
 	c.PaymentsTransactions = &PaymentsTransactionsServiceOp{client: c}
 	c.OrderRisk = &OrderRiskServiceOp{client: c}
+	c.ApiPermissions = &ApiPermissionsServiceOp{client: c}
 
 	// apply any options
 	for _, opt := range opts {


### PR DESCRIPTION
Add the ability to uninstall an app over the Shopify REST API by calling DELETE on the admin/api_permissions resource. Documentation for this functionality is found on Shopify API docs [here](https://shopify.dev/docs/apps/auth/installation/uninstall-app). Note that DELETE is the only method allowed on the api_permissions resource, hence it is the only method implemented.

I’ve added a test and tested manually to confirm this works, but please let me know if I’ve missed anything!