### PR TITLE
fix: ProductListOptions are missing some fields (#253)

### DIFF
--- a/product.go
+++ b/product.go
@@ -101,6 +101,7 @@ type ProductListOptions struct {
 	PublishedStatus       string          `url:"published_status,omitempty"`
 	PresentmentCurrencies string          `url:"presentment_currencies,omitempty"`
 	Status                []ProductStatus `url:"status,omitempty,comma"`
+	Title                 string          `url:"title,omitempty"`
 }
 
 // Represents the result from the products/X.json endpoint


### PR DESCRIPTION
close #253 

- add field `title`