### PR TITLE
Fix ShippingLines.Id type

### DIFF
--- a/fixtures/shippinglines/requested_fulfillment_service_id_invalid.json
+++ b/fixtures/shippinglines/requested_fulfillment_service_id_invalid.json
@@ -1,5 +1,5 @@
 {
-  "id": 254721542,
+  "id": "some-id",
   "code": "INT.TP",
   "price": "4.00",
   "price_set": {

--- a/fixtures/shippinglines/requested_fulfillment_service_id_null.json
+++ b/fixtures/shippinglines/requested_fulfillment_service_id_null.json
@@ -1,5 +1,5 @@
 {
-  "id": 254721542,
+  "id": "some-id",
   "code": "INT.TP",
   "price": "4.00",
   "price_set": {

--- a/fixtures/shippinglines/requested_fulfillment_service_id_number.json
+++ b/fixtures/shippinglines/requested_fulfillment_service_id_number.json
@@ -1,5 +1,5 @@
 {
-  "id": 254721542,
+  "id": "some-id",
   "code": "INT.TP",
   "price": "4.00",
   "price_set": {

--- a/fixtures/shippinglines/valid.json
+++ b/fixtures/shippinglines/valid.json
@@ -1,5 +1,5 @@
 {
-  "id": 254721542,
+  "id": "some-id",
   "code": "INT.TP",
   "price": "4.00",
   "price_set": {

--- a/order.go
+++ b/order.go
@@ -411,7 +411,7 @@ type PaymentDetails struct {
 }
 
 type ShippingLines struct {
-	Id                            uint64           `json:"id,omitempty"`
+	Id                            string           `json:"id,omitempty"`
 	Title                         string           `json:"title,omitempty"`
 	Price                         *decimal.Decimal `json:"price,omitempty"`
 	PriceSet                      *AmountSet       `json:"price_set,omitempty"`
@@ -427,7 +427,8 @@ type ShippingLines struct {
 	Handle                        string           `json:"handle,omitempty"`
 }
 
-// UnmarshalJSON custom unmarshaller for ShippingLines implemented to handle requested_fulfillment_service_id being
+// UnmarshalJSON custom unmarshaller for ShippingLines implemented
+// to handle requested_fulfillment_service_id being
 // returned as json numbers or json nulls instead of json strings
 func (sl *ShippingLines) UnmarshalJSON(data []byte) error {
 	type alias ShippingLines

--- a/order_test.go
+++ b/order_test.go
@@ -1309,7 +1309,7 @@ func validShippingLines() ShippingLines {
 	tl2Rate := decimal.New(5, -2)
 
 	return ShippingLines{
-		Id:    uint64(254721542),
+		Id:    "some-id",
 		Title: "Small Packet International Air",
 		Price: &price,
 		PriceSet: &AmountSet{


### PR DESCRIPTION
# What
Update ShippingLines.Id to string from uint64

# Why
While querying the AbandonedCheckout endpoint the resulting response from shopify rest  api . the Id is not a number but a string. Thus throwing an error while unmarshaling the records.