### PR TITLE
add VariantId to AssignedFulfillmentOrder

### DIFF
--- a/assigned_fulfillment_order.go
+++ b/assigned_fulfillment_order.go
@@ -52,6 +52,7 @@ type AssignedFulfillmentOrderLineItem struct {
 	InventoryItemId     uint64 `json:"inventory_item_id,omitempty"`
 	Quantity            uint64 `json:"quantity,omitempty"`
 	FulfillableQuantity uint64 `json:"fulfillable_quantity,omitempty"`
+	VariantId           uint64 `json:"variant_id,omitempty"`
 }
 
 // AssignedFulfillmentOrderResource represents the result from the assigned_fulfillment_order.json endpoint


### PR DESCRIPTION
VariantId is missing in the official documentation but it's being transmitted and it's important for mapping the products of the orders