### PR TITLE
Add alt member variable to Image tag. 

### DIFF
--- a/fixtures/image.json
+++ b/fixtures/image.json
@@ -7,6 +7,7 @@
         "updated_at": "2017-07-24T19:09:43-00:00",
         "width": 123,
         "height": 456,
+        "alt": "new alt tag content",
         "src": "https:\/\/cdn.shopify.com\/s\/files\/1\/0006\/9093\/3842\/products\/ipod-nano.png?v=1500937783",
         "variant_ids": [
           808950810,

--- a/fixtures/images.json
+++ b/fixtures/images.json
@@ -8,6 +8,7 @@
         "updated_at": "2017-07-24T19:09:43-00:00",
         "width": 123,
         "height": 456,
+        "alt": "new alt tag content",
         "src": "https:\/\/cdn.shopify.com\/s\/files\/1\/0006\/9093\/3842\/products\/ipod-nano.png?v=1500937783",
         "variant_ids": [
           808950810,
@@ -22,6 +23,7 @@
         "updated_at": "2017-07-24T19:09:43-04:00",
         "width": 123,
         "height": 456,
+        "alt": "new alt tag content 2",
         "src": "https:\/\/cdn.shopify.com\/s\/files\/1\/0006\/9093\/3842\/products\/ipod-nano-2.png?v=1500937783",
         "variant_ids": [
         ]

--- a/image.go
+++ b/image.go
@@ -36,6 +36,7 @@ type Image struct {
 	Src               string     `json:"src,omitempty"`
 	Attachment        string     `json:"attachment,omitempty"`
 	Filename          string     `json:"filename,omitempty"`
+	Alt               string     `json:"alt,omitempty"`
 	VariantIds        []uint64   `json:"variant_ids,omitempty"`
 	AdminGraphqlApiId string     `json:"admin_graphql_api_id,omitempty"`
 }

--- a/image_test.go
+++ b/image_test.go
@@ -58,6 +58,11 @@ func imageTests(t *testing.T, image Image) {
 		t.Errorf("Image.VariantIds[0] returned %+v, expected %+v", image.VariantIds[1], expectedVariantIds[1])
 	}
 
+	expectedAlt := "new alt tag content"
+	if image.Alt != expectedAlt {
+		t.Errorf("Image.Alt returned %+v, expected %+v", image.Alt, expectedSrc)
+	}
+
 	// Check that CreatedAt date is set
 	expectedCreatedAt := time.Date(2017, time.July, 24, 19, 9, 43, 0, time.UTC)
 	if !expectedCreatedAt.Equal(*image.CreatedAt) {


### PR DESCRIPTION
The tag is already supported by Shopify as evident in https://shopify.dev/docs/api/admin-rest/2024-01/resources/product-image