### PR TITLE
Changed order.shipping_lines.id to uint64

### DIFF
--- a/fixtures/shippinglines/requested_fulfillment_service_id_invalid.json
+++ b/fixtures/shippinglines/requested_fulfillment_service_id_invalid.json
@@ -1,5 +1,5 @@
 {
-  "id": "some-id",
+  "id": 123456789,
   "code": "INT.TP",
   "price": "4.00",
   "price_set": {

--- a/fixtures/shippinglines/requested_fulfillment_service_id_null.json
+++ b/fixtures/shippinglines/requested_fulfillment_service_id_null.json
@@ -1,5 +1,5 @@
 {
-  "id": "some-id",
+  "id": 123456789,
   "code": "INT.TP",
   "price": "4.00",
   "price_set": {

--- a/fixtures/shippinglines/requested_fulfillment_service_id_number.json
+++ b/fixtures/shippinglines/requested_fulfillment_service_id_number.json
@@ -1,5 +1,5 @@
 {
-  "id": "some-id",
+  "id": 123456789,
   "code": "INT.TP",
   "price": "4.00",
   "price_set": {

--- a/fixtures/shippinglines/valid.json
+++ b/fixtures/shippinglines/valid.json
@@ -1,5 +1,5 @@
 {
-  "id": "some-id",
+  "id": 123456789,
   "code": "INT.TP",
   "price": "4.00",
   "price_set": {

--- a/order.go
+++ b/order.go
@@ -487,7 +487,7 @@ type PaymentDetails struct {
 }
 
 type ShippingLines struct {
-	Id                            string           `json:"id,omitempty"`
+	Id                            uint64           `json:"id,omitempty"`
 	Title                         string           `json:"title,omitempty"`
 	Price                         *decimal.Decimal `json:"price,omitempty"`
 	PriceSet                      *AmountSet       `json:"price_set,omitempty"`

--- a/order_test.go
+++ b/order_test.go
@@ -1421,7 +1421,7 @@ func validShippingLines() ShippingLines {
 	tl2Rate := decimal.New(5, -2)
 
 	return ShippingLines{
-		Id:    "some-id",
+		Id:    123456789,
 		Title: "Small Packet International Air",
 		Price: &price,
 		PriceSet: &AmountSet{


### PR DESCRIPTION
The shipping_lines return their ID as an uint64, not a string. I've updated this in the fixtures as well.