### PR TITLE
Added subtotal and total tax sets to RefundLineItem

### DIFF
--- a/order.go
+++ b/order.go
@@ -597,12 +597,14 @@ const (
 )
 
 type RefundLineItem struct {
-	Id         uint64           `json:"id,omitempty"`
-	Quantity   int              `json:"quantity,omitempty"`
-	LineItemId uint64           `json:"line_item_id,omitempty"`
-	LineItem   *LineItem        `json:"line_item,omitempty"`
-	Subtotal   *decimal.Decimal `json:"subtotal,omitempty"`
-	TotalTax   *decimal.Decimal `json:"total_tax,omitempty"`
+	Id          uint64           `json:"id,omitempty"`
+	Quantity    int              `json:"quantity,omitempty"`
+	LineItemId  uint64           `json:"line_item_id,omitempty"`
+	LineItem    *LineItem        `json:"line_item,omitempty"`
+	Subtotal    *decimal.Decimal `json:"subtotal,omitempty"`
+	TotalTax    *decimal.Decimal `json:"total_tax,omitempty"`
+	SubTotalSet *AmountSet       `json:"subtotal_set,omitempty"`
+	TotalTaxSet *AmountSet       `json:"total_tax_set,omitempty"`
 }
 
 // List orders

--- a/variant.go
+++ b/variant.go
@@ -81,13 +81,8 @@ type Variant struct {
 }
 
 type presentmentPrices struct {
-	Price          *presentmentPrice `json:"price,omitempty"`
-	CompareAtPrice *presentmentPrice `json:"compare_at_price,omitempty"`
-}
-
-type presentmentPrice struct {
-	Amount       string `json:"amount,omitempty"`
-	CurrencyCode string `json:"currency_code,omitempty"`
+	Price          *AmountSetEntry `json:"price,omitempty"`
+	CompareAtPrice *AmountSetEntry `json:"compare_at_price,omitempty"`
 }
 
 // VariantResource represents the result from the variants/X.json endpoint


### PR DESCRIPTION
Added missing fields from RefundLineItem.
Additionally updated presentmentPrices to re-use the same object (no sense in defining the same type multiple places with different names)