### PR TITLE
Removes delivery_category field

### DIFF
--- a/order.go
+++ b/order.go
@@ -497,7 +497,6 @@ type ShippingLines struct {
 	Source                        string           `json:"source,omitempty"`
 	Phone                         string           `json:"phone,omitempty"`
 	RequestedFulfillmentServiceId string           `json:"requested_fulfillment_service_id,omitempty"`
-	DeliveryCategory              string           `json:"delivery_category,omitempty"`
 	CarrierIdentifier             string           `json:"carrier_identifier,omitempty"`
 	TaxLines                      []TaxLine        `json:"tax_lines,omitempty"`
 	Handle                        string           `json:"handle,omitempty"`

--- a/order_test.go
+++ b/order_test.go
@@ -1266,10 +1266,6 @@ func testShippingLines(t *testing.T, expected, actual ShippingLines) {
 		t.Errorf("ShippingLines.RequestedFulfillmentServiceId should be (%v), was (%v)", expected.RequestedFulfillmentServiceId, actual.RequestedFulfillmentServiceId)
 	}
 
-	if actual.DeliveryCategory != expected.DeliveryCategory {
-		t.Errorf("ShippingLines.DeliveryCategory should be (%v), was (%v)", expected.DeliveryCategory, actual.DeliveryCategory)
-	}
-
 	if actual.CarrierIdentifier != expected.CarrierIdentifier {
 		t.Errorf("ShippingLines.CarrierIdentifier should be (%v), was (%v)", expected.CarrierIdentifier, actual.CarrierIdentifier)
 	}
@@ -1449,7 +1445,6 @@ func validShippingLines() ShippingLines {
 		Source:                        "canada_post",
 		Phone:                         "",
 		RequestedFulfillmentServiceId: "third_party_fulfillment_service_id",
-		DeliveryCategory:              "",
 		CarrierIdentifier:             "third_party_carrier_identifier",
 		TaxLines: []TaxLine{
 			{


### PR DESCRIPTION
Removes deprecated delivery_category field on order shipping lines.
https://shopify.dev/changelog/removal-of-the-delivery_category-field-on-order-shipping-lines