### PR TITLE
deprecate Usagecharge->BillingOn

### DIFF
--- a/goshopify_test.go
+++ b/goshopify_test.go
@@ -987,8 +987,6 @@ func TestListWithPagination(t *testing.T) {
 		t.Fatalf("Expected pagination options but found at least one of them nil")
 	}
 
-	t.Logf("b: %#v \n", *pagination.NextPageOptions)
-
 	if pagination.NextPageOptions.PageInfo != "abc" {
 		t.Fatalf("Expected next page: %s   got: %s", "abc", pagination.NextPageOptions.PageInfo)
 	}

--- a/usagecharge.go
+++ b/usagecharge.go
@@ -2,7 +2,6 @@ package goshopify
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -30,32 +29,11 @@ type UsageChargeServiceOp struct {
 type UsageCharge struct {
 	BalanceRemaining *decimal.Decimal `json:"balance_remaining,omitempty"`
 	BalanceUsed      *decimal.Decimal `json:"balance_used,omitempty"`
-	BillingOn        *time.Time       `json:"billing_on,omitempty"`
 	CreatedAt        *time.Time       `json:"created_at,omitempty"`
 	Description      string           `json:"description,omitempty"`
 	Id               uint64           `json:"id,omitempty"`
 	Price            *decimal.Decimal `json:"price,omitempty"`
 	RiskLevel        *decimal.Decimal `json:"risk_level,omitempty"`
-}
-
-func (r *UsageCharge) UnmarshalJSON(data []byte) error {
-	// This is a workaround for the API returning BillingOn date in the format of "YYYY-MM-DD"
-	// https://help.shopify.com/en/api/reference/billing/usagecharge#endpoints
-	// For a longer explanation of the hack check:
-	// http://choly.ca/post/go-json-marshalling/
-	type alias UsageCharge
-	aux := &struct {
-		BillingOn *string `json:"billing_on"`
-		*alias
-	}{alias: (*alias)(r)}
-
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	if err := parse(&r.BillingOn, aux.BillingOn); err != nil {
-		return err
-	}
-	return nil
 }
 
 // UsageChargeResource represents the result from the

--- a/usagecharge_test.go
+++ b/usagecharge_test.go
@@ -13,7 +13,6 @@ import (
 func usageChargeTests(t *testing.T, usageCharge UsageCharge) {
 	price := decimal.NewFromFloat(1.0)
 	createdAt, _ := time.Parse(time.RFC3339, "2018-07-05T13:05:43-04:00")
-	billingOn, _ := time.Parse("2006-01-02", "2018-08-04")
 	balanceUsed := decimal.NewFromFloat(11.0)
 	balancedRemaining := decimal.NewFromFloat(89.0)
 	riskLevel := decimal.NewFromFloat(0.08)
@@ -23,7 +22,6 @@ func usageChargeTests(t *testing.T, usageCharge UsageCharge) {
 		Description:      "Super Mega Plan 1000 emails",
 		Price:            &price,
 		CreatedAt:        &createdAt,
-		BillingOn:        &billingOn,
 		BalanceRemaining: &balancedRemaining,
 		BalanceUsed:      &balanceUsed,
 		RiskLevel:        &riskLevel,
@@ -40,9 +38,6 @@ func usageChargeTests(t *testing.T, usageCharge UsageCharge) {
 	}
 	if !usageCharge.CreatedAt.Equal(*expected.CreatedAt) {
 		t.Errorf("UsageCharge.CreatedAt returned %v, expected %v", usageCharge.CreatedAt, expected.CreatedAt)
-	}
-	if !usageCharge.BillingOn.Equal(*expected.BillingOn) {
-		t.Errorf("UsageCharge.BillingOn returned %v, expected %v", usageCharge.BillingOn, expected.BillingOn)
 	}
 	if !usageCharge.BalanceRemaining.Equal(*expected.BalanceRemaining) {
 		t.Errorf("UsageCharge.BalanceRemaining returned %v, expected %v", usageCharge.BalanceRemaining, expected.BalanceRemaining)
@@ -137,17 +132,6 @@ func TestUsageChargeServiceOp_GetBadFields(t *testing.T) {
 		),
 	)
 
-	if _, err := client.UsageCharge.Get(context.Background(), 455696195, 1034618210, nil); err == nil {
-		t.Errorf("UsageCharge.Get should have returned an error")
-	}
-
-	httpmock.RegisterResponder(
-		"GET",
-		fmt.Sprintf("https://fooshop.myshopify.com/%s/recurring_application_charges/455696195/usage_charges/1034618210.json", client.pathPrefix),
-		httpmock.NewStringResponder(
-			200, `{"usage_charge":{"billing_on":"2018-14-01"}}`,
-		),
-	)
 	if _, err := client.UsageCharge.Get(context.Background(), 455696195, 1034618210, nil); err == nil {
 		t.Errorf("UsageCharge.Get should have returned an error")
 	}


### PR DESCRIPTION
https://shopify.dev/changelog/removal-of-usagecharge-billing_on-field-on-admin-rest-api

> As of Admin REST API version 2023-10, the following UsageCharge fields have been deprecated: billing_on.
> Learn more about the UsageCharge object on [Shopify.dev](https://shopify.dev/docs/api/admin-rest/2022-10/resources/usagecharge).