### PR TITLE
added current_quantity to LineItem

### DIFF
--- a/order.go
+++ b/order.go
@@ -374,6 +374,7 @@ type LineItem struct {
 	ProductId                  uint64                 `json:"product_id,omitempty"`
 	VariantId                  uint64                 `json:"variant_id,omitempty"`
 	Quantity                   int                    `json:"quantity,omitempty"`
+	CurrentQuantity            int                    `json:"current_quantity,omitempty"`
 	Price                      *decimal.Decimal       `json:"price,omitempty"`
 	TotalDiscount              *decimal.Decimal       `json:"total_discount,omitempty"`
 	Title                      string                 `json:"title,omitempty"`


### PR DESCRIPTION
Added current_quantity to LineItem. 
This addition is documented in the following release notes
https://shopify.dev/docs/api/release-notes/2024-01#rest-admin-api-changes