### PR TITLE
Add published param to Page

### DIFF
--- a/page.go
+++ b/page.go
@@ -44,6 +44,7 @@ type Page struct {
 	BodyHTML       string      `json:"body_html,omitempty"`
 	TemplateSuffix string      `json:"template_suffix,omitempty"`
 	PublishedAt    *time.Time  `json:"published_at,omitempty"`
+	Published      bool        `json:"published,omitempty"` // Mainly used for create/update
 	ShopId         uint64      `json:"shop_id,omitempty"`
 	Metafields     []Metafield `json:"metafields,omitempty"`
 }
@@ -63,6 +64,11 @@ func (s *PageServiceOp) List(ctx context.Context, options interface{}) ([]Page, 
 	path := fmt.Sprintf("%s.json", pagesBasePath)
 	resource := new(PagesResource)
 	err := s.client.Get(ctx, path, resource, options)
+	for i, page := range resource.Pages {
+		if page.PublishedAt != nil {
+			resource.Pages[i].Published = true
+		}
+	}
 	return resource.Pages, err
 }
 
@@ -77,6 +83,9 @@ func (s *PageServiceOp) Get(ctx context.Context, pageId uint64, options interfac
 	path := fmt.Sprintf("%s/%d.json", pagesBasePath, pageId)
 	resource := new(PageResource)
 	err := s.client.Get(ctx, path, resource, options)
+	if resource.Page != nil && resource.Page.PublishedAt != nil {
+		resource.Page.Published = true
+	}
 	return resource.Page, err
 }
 
@@ -86,6 +95,9 @@ func (s *PageServiceOp) Create(ctx context.Context, page Page) (*Page, error) {
 	wrappedData := PageResource{Page: &page}
 	resource := new(PageResource)
 	err := s.client.Post(ctx, path, wrappedData, resource)
+	if resource.Page != nil && resource.Page.PublishedAt != nil {
+		resource.Page.Published = true
+	}
 	return resource.Page, err
 }
 
@@ -95,6 +107,9 @@ func (s *PageServiceOp) Update(ctx context.Context, page Page) (*Page, error) {
 	wrappedData := PageResource{Page: &page}
 	resource := new(PageResource)
 	err := s.client.Put(ctx, path, wrappedData, resource)
+	if resource.Page != nil && resource.Page.PublishedAt != nil {
+		resource.Page.Published = true
+	}
 	return resource.Page, err
 }
 

--- a/page.go
+++ b/page.go
@@ -35,18 +35,20 @@ type PageServiceOp struct {
 
 // Page represents a Shopify page.
 type Page struct {
-	Id             uint64      `json:"id,omitempty"`
-	Author         string      `json:"author,omitempty"`
-	Handle         string      `json:"handle,omitempty"`
-	Title          string      `json:"title,omitempty"`
-	CreatedAt      *time.Time  `json:"created_at,omitempty"`
-	UpdatedAt      *time.Time  `json:"updated_at,omitempty"`
-	BodyHTML       string      `json:"body_html,omitempty"`
-	TemplateSuffix string      `json:"template_suffix,omitempty"`
-	PublishedAt    *time.Time  `json:"published_at,omitempty"`
-	Published      bool        `json:"published,omitempty"` // Mainly used for create/update
-	ShopId         uint64      `json:"shop_id,omitempty"`
-	Metafields     []Metafield `json:"metafields,omitempty"`
+	Id             uint64     `json:"id,omitempty"`
+	Author         string     `json:"author,omitempty"`
+	Handle         string     `json:"handle,omitempty"`
+	Title          string     `json:"title,omitempty"`
+	CreatedAt      *time.Time `json:"created_at,omitempty"`
+	UpdatedAt      *time.Time `json:"updated_at,omitempty"`
+	BodyHTML       string     `json:"body_html,omitempty"`
+	TemplateSuffix string     `json:"template_suffix,omitempty"`
+	PublishedAt    *time.Time `json:"published_at,omitempty"`
+	// Published can be set when creating a new page.
+	// It's not returned in the response
+	Published  *bool       `json:"published,omitempty"`
+	ShopId     uint64      `json:"shop_id,omitempty"`
+	Metafields []Metafield `json:"metafields,omitempty"`
 }
 
 // PageResource represents the result from the pages/X.json endpoint
@@ -64,11 +66,6 @@ func (s *PageServiceOp) List(ctx context.Context, options interface{}) ([]Page, 
 	path := fmt.Sprintf("%s.json", pagesBasePath)
 	resource := new(PagesResource)
 	err := s.client.Get(ctx, path, resource, options)
-	for i, page := range resource.Pages {
-		if page.PublishedAt != nil {
-			resource.Pages[i].Published = true
-		}
-	}
 	return resource.Pages, err
 }
 
@@ -83,9 +80,6 @@ func (s *PageServiceOp) Get(ctx context.Context, pageId uint64, options interfac
 	path := fmt.Sprintf("%s/%d.json", pagesBasePath, pageId)
 	resource := new(PageResource)
 	err := s.client.Get(ctx, path, resource, options)
-	if resource.Page != nil && resource.Page.PublishedAt != nil {
-		resource.Page.Published = true
-	}
 	return resource.Page, err
 }
 
@@ -95,9 +89,6 @@ func (s *PageServiceOp) Create(ctx context.Context, page Page) (*Page, error) {
 	wrappedData := PageResource{Page: &page}
 	resource := new(PageResource)
 	err := s.client.Post(ctx, path, wrappedData, resource)
-	if resource.Page != nil && resource.Page.PublishedAt != nil {
-		resource.Page.Published = true
-	}
 	return resource.Page, err
 }
 
@@ -107,9 +98,6 @@ func (s *PageServiceOp) Update(ctx context.Context, page Page) (*Page, error) {
 	wrappedData := PageResource{Page: &page}
 	resource := new(PageResource)
 	err := s.client.Put(ctx, path, wrappedData, resource)
-	if resource.Page != nil && resource.Page.PublishedAt != nil {
-		resource.Page.Published = true
-	}
 	return resource.Page, err
 }
 

--- a/page_test.go
+++ b/page_test.go
@@ -23,14 +23,17 @@ func TestPageList(t *testing.T) {
 	defer teardown()
 
 	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages.json", client.pathPrefix),
-		httpmock.NewStringResponder(200, `{"pages": [{"id":1},{"id":2}]}`))
+		httpmock.NewStringResponder(200, `{"pages": [{"id":1,"published_at": "2008-07-15T20:00:00Z"},{"id":2,"published_at": "2008-07-15T21:00:00Z"}]}`))
 
 	pages, err := client.Page.List(context.Background(), nil)
 	if err != nil {
 		t.Errorf("Page.List returned error: %v", err)
 	}
 
-	expected := []Page{{Id: 1}, {Id: 2}}
+	expected := []Page{
+		{Id: 1, PublishedAt: TimePtr(time.Date(2008, 7, 15, 20, 0, 0, 0, time.UTC)), Published: true},
+		{Id: 2, PublishedAt: TimePtr(time.Date(2008, 7, 15, 21, 0, 0, 0, time.UTC)), Published: true},
+	}
 	if !reflect.DeepEqual(pages, expected) {
 		t.Errorf("Page.List returned %+v, expected %+v", pages, expected)
 	}
@@ -77,14 +80,14 @@ func TestPageGet(t *testing.T) {
 	defer teardown()
 
 	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/pages/1.json", client.pathPrefix),
-		httpmock.NewStringResponder(200, `{"page": {"id":1}}`))
+		httpmock.NewStringResponder(200, `{"page": {"id":1,"published_at": "2008-07-15T20:00:00Z"}}`))
 
 	page, err := client.Page.Get(context.Background(), 1, nil)
 	if err != nil {
 		t.Errorf("Page.Get returned error: %v", err)
 	}
 
-	expected := &Page{Id: 1}
+	expected := &Page{Id: 1, PublishedAt: TimePtr(time.Date(2008, 7, 15, 20, 0, 0, 0, time.UTC)), Published: true}
 	if !reflect.DeepEqual(page, expected) {
 		t.Errorf("Page.Get returned %+v, expected %+v", page, expected)
 	}

--- a/page_test.go
+++ b/page_test.go
@@ -31,8 +31,8 @@ func TestPageList(t *testing.T) {
 	}
 
 	expected := []Page{
-		{Id: 1, PublishedAt: TimePtr(time.Date(2008, 7, 15, 20, 0, 0, 0, time.UTC)), Published: true},
-		{Id: 2, PublishedAt: TimePtr(time.Date(2008, 7, 15, 21, 0, 0, 0, time.UTC)), Published: true},
+		{Id: 1, PublishedAt: TimePtr(time.Date(2008, 7, 15, 20, 0, 0, 0, time.UTC))},
+		{Id: 2, PublishedAt: TimePtr(time.Date(2008, 7, 15, 21, 0, 0, 0, time.UTC))},
 	}
 	if !reflect.DeepEqual(pages, expected) {
 		t.Errorf("Page.List returned %+v, expected %+v", pages, expected)
@@ -87,7 +87,7 @@ func TestPageGet(t *testing.T) {
 		t.Errorf("Page.Get returned error: %v", err)
 	}
 
-	expected := &Page{Id: 1, PublishedAt: TimePtr(time.Date(2008, 7, 15, 20, 0, 0, 0, time.UTC)), Published: true}
+	expected := &Page{Id: 1, PublishedAt: TimePtr(time.Date(2008, 7, 15, 20, 0, 0, 0, time.UTC))}
 	if !reflect.DeepEqual(page, expected) {
 		t.Errorf("Page.Get returned %+v, expected %+v", page, expected)
 	}

--- a/util.go
+++ b/util.go
@@ -81,3 +81,7 @@ func (c *OnlyDate) EncodeValues(key string, v *url.Values) error {
 func (c *OnlyDate) String() string {
 	return `"` + c.Format("2006-01-02") + `"`
 }
+
+func TimePtr(v time.Time) *time.Time {
+	return &v
+}


### PR DESCRIPTION
This PR adds `Published` field to Page to make it possible to pass `published` parameter for create/update.
Also not to let user confuse, the field will be consistent with `published_at` when it's read.
```shell
curl -d '{"page":{"title":"Warranty information","body_html":"<h2>Warranty</h2>\n<p>Returns accepted if we receive items <strong>30 days after purchase</strong>.</p>","published":false}}' \
-X POST "https://your-development-store.myshopify.com/admin/api/2024-07/pages.json" \
-H "X-Shopify-Access-Token: {access_token}" \
-H "Content-Type: application/json"
```
https://shopify.dev/docs/api/admin-rest/2024-07/resources/page#post-pages-examples