### PR TITLE
Update country_harmonized_system_codes type in InventoryItem

### DIFF
--- a/fixtures/inventory_item.json
+++ b/fixtures/inventory_item.json
@@ -8,7 +8,16 @@
       "tracked": true,
       "admin_graphql_api_id": "gid://shopify/InventoryItem/808950810",
       "country_code_of_origin": "US",
-      "country_harmonized_system_codes": ["8471.70.40.35", "8471.70.50.35"],
+      "country_harmonized_system_codes": [
+        {
+          "harmonized_system_code": "8471.70.40.35",
+          "country_code": "US"
+        },
+        {
+          "harmonized_system_code": "8471.70.50.35",
+          "country_code": "CA"
+        }
+      ],
       "harmonized_system_code": "8471.70.40.35",
       "province_code_of_origin": "ON"
     }

--- a/inventory_item.go
+++ b/inventory_item.go
@@ -24,19 +24,25 @@ type InventoryItemServiceOp struct {
 	client *Client
 }
 
+// CountryHarmonizedSystemCode represents a harmonized system code for a specific country
+type CountryHarmonizedSystemCode struct {
+	HarmonizedSystemCode string `json:"harmonized_system_code"`
+	CountryCode          string `json:"country_code"`
+}
+
 // InventoryItem represents a Shopify inventory item
 type InventoryItem struct {
-	Id                           uint64           `json:"id,omitempty"`
-	SKU                          string           `json:"sku,omitempty"`
-	CreatedAt                    *time.Time       `json:"created_at,omitempty"`
-	UpdatedAt                    *time.Time       `json:"updated_at,omitempty"`
-	Cost                         *decimal.Decimal `json:"cost,omitempty"`
-	Tracked                      *bool            `json:"tracked,omitempty"`
-	AdminGraphqlApiId            string           `json:"admin_graphql_api_id,omitempty"`
-	CountryCodeOfOrigin          *string          `json:"country_code_of_origin"`
-	CountryHarmonizedSystemCodes []string         `json:"country_harmonized_system_codes"`
-	HarmonizedSystemCode         *string          `json:"harmonized_system_code"`
-	ProvinceCodeOfOrigin         *string          `json:"province_code_of_origin"`
+	Id                           uint64                        `json:"id,omitempty"`
+	SKU                          string                        `json:"sku,omitempty"`
+	CreatedAt                    *time.Time                    `json:"created_at,omitempty"`
+	UpdatedAt                    *time.Time                    `json:"updated_at,omitempty"`
+	Cost                         *decimal.Decimal              `json:"cost,omitempty"`
+	Tracked                      *bool                         `json:"tracked,omitempty"`
+	AdminGraphqlApiId            string                        `json:"admin_graphql_api_id,omitempty"`
+	CountryCodeOfOrigin          *string                       `json:"country_code_of_origin"`
+	CountryHarmonizedSystemCodes []CountryHarmonizedSystemCode `json:"country_harmonized_system_codes"`
+	HarmonizedSystemCode         *string                       `json:"harmonized_system_code"`
+	ProvinceCodeOfOrigin         *string                       `json:"province_code_of_origin"`
 }
 
 // InventoryItemResource is used for handling single item requests and responses

--- a/inventory_item_test.go
+++ b/inventory_item_test.go
@@ -3,7 +3,6 @@ package goshopify
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
@@ -41,11 +40,25 @@ func inventoryItemTests(t *testing.T, item *InventoryItem) {
 		t.Errorf("InventoryItem.CountryCodeOfOrigin returned %+v, expected %+v", item.CountryCodeOfOrigin, expectedOrigin)
 	}
 
-	// strings.Join is used to compare slices since package's go.mod is set to 1.13
-	// which predates the experimental slices package that has a Compare() func.
-	expectedCountryHSCodes := strings.Join([]string{"8471.70.40.35", "8471.70.50.35"}, ",")
-	if strings.Join(item.CountryHarmonizedSystemCodes, ",") != expectedCountryHSCodes {
-		t.Errorf("InventoryItem.CountryHarmonizedSystemCodes returned %+v, expected %+v", item.CountryHarmonizedSystemCodes, expectedCountryHSCodes)
+	expectedCodes := []CountryHarmonizedSystemCode{
+		{HarmonizedSystemCode: "8471.70.40.35", CountryCode: "US"},
+		{HarmonizedSystemCode: "8471.70.50.35", CountryCode: "CA"},
+	}
+
+	if len(item.CountryHarmonizedSystemCodes) != len(expectedCodes) {
+		t.Errorf("InventoryItem.CountryHarmonizedSystemCodes length is %d, expected %d",
+			len(item.CountryHarmonizedSystemCodes), len(expectedCodes))
+	}
+
+	for i, code := range item.CountryHarmonizedSystemCodes {
+		if code.HarmonizedSystemCode != expectedCodes[i].HarmonizedSystemCode {
+			t.Errorf("InventoryItem.CountryHarmonizedSystemCodes[%d].HarmonizedSystemCode is %s, expected %s",
+				i, code.HarmonizedSystemCode, expectedCodes[i].HarmonizedSystemCode)
+		}
+		if code.CountryCode != expectedCodes[i].CountryCode {
+			t.Errorf("InventoryItem.CountryHarmonizedSystemCodes[%d].CountryCode is %s, expected %s",
+				i, code.CountryCode, expectedCodes[i].CountryCode)
+		}
 	}
 
 	expectedHSCode := "8471.70.40.35"


### PR DESCRIPTION
Fix: update country_harmonized_system_codes type in InventoryItem

The country_harmonized_system_codes field was previously defined as []string, but according to Shopify’s API documentation, it should be an array of objects. This PR introduces the CountryHarmonizedSystemCode struct and updates the InventoryItem type to use []CountryHarmonizedSystemCode, ensuring the JSON format matches the expected schema.

[Link to the issue](https://github.com/bold-commerce/go-shopify/issues/318)