### PR TITLE
Fix outdated links to shopify API docs (bold-commerce#325)

### DIFF
--- a/api_permissions.go
+++ b/api_permissions.go
@@ -9,7 +9,7 @@ const apiPermissionsBasePath = "api_permissions"
 
 // ApiPermissionsService is an interface for interfacing with the API
 // permissions endpoints of the Shopify API.
-// See: https://help.shopify.com/api/reference/theme
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/theme
 type ApiPermissionsService interface {
 	Delete(context.Context) error
 }

--- a/applicationcharge.go
+++ b/applicationcharge.go
@@ -12,7 +12,7 @@ const applicationChargesBasePath = "application_charges"
 
 // ApplicationChargeService is an interface for interacting with the
 // ApplicationCharge endpoints of the Shopify API.
-// See https://help.shopify.com/api/reference/billing/applicationcharge
+// See https://shopify.dev/docs/api/admin-rest/latest/resources/applicationcharge
 type ApplicationChargeService interface {
 	Create(context.Context, ApplicationCharge) (*ApplicationCharge, error)
 	Get(context.Context, uint64, interface{}) (*ApplicationCharge, error)

--- a/asset.go
+++ b/asset.go
@@ -10,7 +10,7 @@ const assetsBasePath = "themes"
 
 // AssetService is an interface for interfacing with the asset endpoints
 // of the Shopify API.
-// See: https://help.shopify.com/api/reference/asset
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/asset
 type AssetService interface {
 	List(context.Context, uint64, interface{}) ([]Asset, error)
 	Get(context.Context, uint64, string) (*Asset, error)

--- a/blog.go
+++ b/blog.go
@@ -10,7 +10,7 @@ const blogsBasePath = "blogs"
 
 // BlogService is an interface for interfacing with the blogs endpoints
 // of the Shopify API.
-// See: https://help.shopify.com/api/reference/online_store/blog
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/blog
 type BlogService interface {
 	List(context.Context, interface{}) ([]Blog, error)
 	Count(context.Context, interface{}) (int, error)

--- a/collect.go
+++ b/collect.go
@@ -10,7 +10,7 @@ const collectsBasePath = "collects"
 
 // CollectService is an interface for interfacing with the collect endpoints
 // of the Shopify API.
-// See: https://help.shopify.com/api/reference/products/collect
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/collect
 type CollectService interface {
 	List(context.Context, interface{}) ([]Collect, error)
 	Count(context.Context, interface{}) (int, error)

--- a/collection.go
+++ b/collection.go
@@ -10,7 +10,7 @@ const collectionsBasePath = "collections"
 
 // CollectionService is an interface for interfacing with the collection endpoints
 // of the Shopify API.
-// See: https://help.shopify.com/api/reference/products/collection
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/collection
 type CollectionService interface {
 	Get(ctx context.Context, collectionId uint64, options interface{}) (*Collection, error)
 	ListProducts(ctx context.Context, collectionId uint64, options interface{}) ([]Product, error)

--- a/customcollection.go
+++ b/customcollection.go
@@ -13,7 +13,7 @@ const (
 
 // CustomCollectionService is an interface for interacting with the custom
 // collection endpoints of the Shopify API.
-// See https://help.shopify.com/api/reference/customcollection
+// See https://shopify.dev/docs/api/admin-rest/latest/resources/customcollection
 type CustomCollectionService interface {
 	List(context.Context, interface{}) ([]CustomCollection, error)
 	Count(context.Context, interface{}) (int, error)

--- a/customer.go
+++ b/customer.go
@@ -15,7 +15,7 @@ const (
 
 // CustomerService is an interface for interfacing with the customers endpoints
 // of the Shopify API.
-// See: https://help.shopify.com/api/reference/customer
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/customer
 type CustomerService interface {
 	List(context.Context, interface{}) ([]Customer, error)
 	ListAll(context.Context, interface{}) ([]Customer, error)

--- a/customer_address.go
+++ b/customer_address.go
@@ -7,7 +7,7 @@ import (
 
 // CustomerAddressService is an interface for interfacing with the customer address endpoints
 // of the Shopify API.
-// See: https://help.shopify.com/en/api/reference/customers/customer_address
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/customer_address
 type CustomerAddressService interface {
 	List(context.Context, uint64, interface{}) ([]CustomerAddress, error)
 	Get(context.Context, uint64, uint64, interface{}) (*CustomerAddress, error)

--- a/discount_code.go
+++ b/discount_code.go
@@ -10,7 +10,7 @@ const discountCodeBasePath = "price_rules/%d/discount_codes"
 
 // DiscountCodeService is an interface for interfacing with the discount endpoints
 // of the Shopify API.
-// See: https://help.shopify.com/en/api/reference/discounts/PriceRuleDiscountCode
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/PriceRuleDiscountCode
 type DiscountCodeService interface {
 	Create(context.Context, uint64, PriceRuleDiscountCode) (*PriceRuleDiscountCode, error)
 	Update(context.Context, uint64, PriceRuleDiscountCode) (*PriceRuleDiscountCode, error)

--- a/draft_order.go
+++ b/draft_order.go
@@ -15,7 +15,7 @@ const (
 
 // DraftOrderService is an interface for interfacing with the draft orders endpoints of
 // the Shopify API.
-// See: https://help.shopify.com/api/reference/orders/draftorder
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/draftorder
 type DraftOrderService interface {
 	List(context.Context, interface{}) ([]DraftOrder, error)
 	Count(context.Context, interface{}) (int, error)

--- a/fulfillment.go
+++ b/fulfillment.go
@@ -8,7 +8,7 @@ import (
 
 // FulfillmentService is an interface for interfacing with the fulfillment endpoints
 // of the Shopify API.
-// https://help.shopify.com/api/reference/fulfillment
+// https://shopify.dev/docs/api/admin-rest/latest/resources/fulfillment
 type FulfillmentService interface {
 	List(context.Context, interface{}) ([]Fulfillment, error)
 	Count(context.Context, interface{}) (int, error)
@@ -22,7 +22,7 @@ type FulfillmentService interface {
 
 // FulfillmentsService is an interface for other Shopify resources
 // to interface with the fulfillment endpoints of the Shopify API.
-// https://help.shopify.com/api/reference/fulfillment
+// https://shopify.dev/docs/api/admin-rest/latest/resources/fulfillment
 type FulfillmentsService interface {
 	ListFulfillments(context.Context, uint64, interface{}) ([]Fulfillment, error)
 	CountFulfillments(context.Context, uint64, interface{}) (int, error)

--- a/fulfillment_event.go
+++ b/fulfillment_event.go
@@ -11,7 +11,7 @@ const (
 
 // FulfillmentEventService is an interface for interfacing with the fulfillment event service
 // of the Shopify API.
-// https://help.shopify.com/api/reference/fulfillmentevent
+// https://shopify.dev/docs/api/admin-rest/latest/resources/fulfillmentevent
 type FulfillmentEventService interface {
 	List(ctx context.Context, orderId uint64, fulfillmentId uint64) ([]FulfillmentEvent, error)
 	Get(ctx context.Context, orderId uint64, fulfillmentId uint64, eventId uint64) (*FulfillmentEvent, error)

--- a/fulfillment_service.go
+++ b/fulfillment_service.go
@@ -10,7 +10,7 @@ const (
 )
 
 // FulfillmentServiceService is an interface for interfacing with the fulfillment service of the Shopify API.
-// https://help.shopify.com/api/reference/fulfillmentservice
+// https://shopify.dev/docs/api/admin-rest/latest/resources/fulfillmentservice
 type FulfillmentServiceService interface {
 	List(context.Context, interface{}) ([]FulfillmentServiceData, error)
 	Get(context.Context, uint64, interface{}) (*FulfillmentServiceData, error)

--- a/goshopify.go
+++ b/goshopify.go
@@ -698,7 +698,7 @@ func (c *Client) ListWithPagination(ctx context.Context, path string, resource, 
 
 // extractPagination extracts pagination info from linkHeader.
 // Details on the format are here:
-// https://help.shopify.com/en/api/guides/paginated-rest-results
+// https://shopify.dev/docs/api/admin-rest/latest/resources/paginated-rest-results
 func extractPagination(linkHeader string) (*Pagination, error) {
 	pagination := new(Pagination)
 

--- a/image.go
+++ b/image.go
@@ -8,7 +8,7 @@ import (
 
 // ImageService is an interface for interacting with the image endpoints
 // of the Shopify API.
-// See https://help.shopify.com/api/reference/product_image
+// See https://shopify.dev/docs/api/admin-rest/latest/resources/product_image
 type ImageService interface {
 	List(context.Context, uint64, interface{}) ([]Image, error)
 	Count(context.Context, uint64, interface{}) (int, error)

--- a/inventory_item.go
+++ b/inventory_item.go
@@ -12,7 +12,7 @@ const inventoryItemsBasePath = "inventory_items"
 
 // InventoryItemService is an interface for interacting with the
 // inventory items endpoints of the Shopify API
-// See https://help.shopify.com/en/api/reference/inventory/inventoryitem
+// See https://shopify.dev/docs/api/admin-rest/latest/resources/inventoryitem
 type InventoryItemService interface {
 	List(context.Context, interface{}) ([]InventoryItem, error)
 	Get(context.Context, uint64, interface{}) (*InventoryItem, error)

--- a/inventory_level.go
+++ b/inventory_level.go
@@ -10,7 +10,7 @@ const inventoryLevelsBasePath = "inventory_levels"
 
 // InventoryLevelService is an interface for interacting with the
 // inventory items endpoints of the Shopify API
-// See https://help.shopify.com/en/api/reference/inventory/inventorylevel
+// See https://shopify.dev/docs/api/admin-rest/latest/resources/inventorylevel
 type InventoryLevelService interface {
 	List(context.Context, interface{}) ([]InventoryLevel, error)
 	Adjust(context.Context, interface{}) (*InventoryLevel, error)

--- a/location.go
+++ b/location.go
@@ -13,7 +13,7 @@ const (
 
 // LocationService is an interface for interfacing with the location endpoints
 // of the Shopify API.
-// See: https://help.shopify.com/en/api/reference/inventory/location
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/location
 type LocationService interface {
 	// Retrieves a list of locations
 	List(ctx context.Context, options interface{}) ([]Location, error)

--- a/metafield.go
+++ b/metafield.go
@@ -8,7 +8,7 @@ import (
 
 // MetafieldService is an interface for interfacing with the metafield endpoints
 // of the Shopify API.
-// https://help.shopify.com/api/reference/metafield
+// https://shopify.dev/docs/api/admin-rest/latest/resources/metafield
 type MetafieldService interface {
 	List(context.Context, interface{}) ([]Metafield, error)
 	Count(context.Context, interface{}) (int, error)
@@ -20,7 +20,7 @@ type MetafieldService interface {
 
 // MetafieldsService is an interface for other Shopify resources
 // to interface with the metafield endpoints of the Shopify API.
-// https://help.shopify.com/api/reference/metafield
+// https://shopify.dev/docs/api/admin-rest/latest/resources/metafield
 type MetafieldsService interface {
 	ListMetafields(context.Context, uint64, interface{}) ([]Metafield, error)
 	CountMetafields(context.Context, uint64, interface{}) (int, error)

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -96,7 +96,7 @@ func TestAppGetAccessTokenError(t *testing.T) {
 
 func TestAppVerifyAuthorizationURL(t *testing.T) {
 	// These credentials are from the Shopify example page:
-	// https://help.shopify.com/api/guides/authentication/oauth#verification
+	// https://shopify.dev/docs/api/admin-rest/latest/resources/oauth#verification
 	urlOk, _ := url.Parse("http://example.com/callback?code=0907a61c0c8d55e99db179b68161bc00&hmac=4712bf92ffc2917d15a2f5a273e39f0116667419aa4b6ac0b3baaf26fa3c4d20&shop=some-shop.myshopify.com&signature=11813d1e7bbf4629edcda0628a3f7a20&timestamp=1337178173")
 	urlOkWithState, _ := url.Parse("http://example.com/callback?code=0907a61c0c8d55e99db179b68161bc00&hmac=7db6973c2aff68295ebcf354c2ce528a6b09aef1146baafccc2e0b369fff5f6d&shop=some-shop.myshopify.com&signature=11813d1e7bbf4629edcda0628a3f7a20&timestamp=1337178173&state=abcd")
 	urlNotOk, _ := url.Parse("http://example.com/callback?code=0907a61c0c8d55e99db179b68161bc00&hmac=4712bf92ffc2917d15a2f5a273e39f0116667419aa4b6ac0b3baaf26fa3c4d20&shop=some-shop.myshopify.com&signature=11813d1e7bbf4629edcda0628a3f7a20&timestamp=133717817")

--- a/order.go
+++ b/order.go
@@ -16,7 +16,7 @@ const (
 
 // OrderService is an interface for interfacing with the orders endpoints of
 // the Shopify API.
-// See: https://help.shopify.com/api/reference/order
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/order
 type OrderService interface {
 	List(context.Context, interface{}) ([]Order, error)
 	ListAll(context.Context, interface{}) ([]Order, error)
@@ -244,7 +244,7 @@ type OrderCountOptions struct {
 }
 
 // OrderListOptions A struct for all available order list options.
-// See: https://help.shopify.com/api/reference/order#index
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/order#index
 type OrderListOptions struct {
 	ListOptions
 	Status            OrderStatus            `url:"status,omitempty"`
@@ -256,7 +256,7 @@ type OrderListOptions struct {
 }
 
 // OrderCancelOptions A struct of all available order cancel options.
-// See: https://help.shopify.com/api/reference/order#index
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/order#index
 type OrderCancelOptions struct {
 	Amount   *decimal.Decimal `json:"amount,omitempty"`
 	Currency string           `json:"currency,omitempty"`

--- a/page.go
+++ b/page.go
@@ -13,7 +13,7 @@ const (
 
 // PagesPageService is an interface for interacting with the pages
 // endpoints of the Shopify API.
-// See https://help.shopify.com/api/reference/online_store/page
+// See https://shopify.dev/docs/api/admin-rest/latest/resources/page
 type PageService interface {
 	List(context.Context, interface{}) ([]Page, error)
 	Count(context.Context, interface{}) (int, error)

--- a/product.go
+++ b/product.go
@@ -17,7 +17,7 @@ var linkRegex = regexp.MustCompile(`^ *<([^>]+)>; rel="(previous|next)" *$`)
 
 // ProductService is an interface for interfacing with the product endpoints
 // of the Shopify API.
-// See: https://help.shopify.com/api/reference/product
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/product
 type ProductService interface {
 	List(context.Context, interface{}) ([]Product, error)
 	ListAll(context.Context, interface{}) ([]Product, error)

--- a/recurringapplicationcharge.go
+++ b/recurringapplicationcharge.go
@@ -13,7 +13,7 @@ const recurringApplicationChargesBasePath = "recurring_application_charges"
 
 // RecurringApplicationChargeService is an interface for interacting with the
 // RecurringApplicationCharge endpoints of the Shopify API.
-// See https://help.shopify.com/api/reference/billing/recurringapplicationcharge
+// See https://shopify.dev/docs/api/admin-rest/latest/resources/recurringapplicationcharge
 type RecurringApplicationChargeService interface {
 	Create(context.Context, RecurringApplicationCharge) (*RecurringApplicationCharge, error)
 	Get(context.Context, uint64, interface{}) (*RecurringApplicationCharge, error)

--- a/redirect.go
+++ b/redirect.go
@@ -9,7 +9,7 @@ const redirectsBasePath = "redirects"
 
 // RedirectService is an interface for interacting with the redirects
 // endpoints of the Shopify API.
-// See https://help.shopify.com/api/reference/online_store/redirect
+// See https://shopify.dev/docs/api/admin-rest/latest/resources/redirect
 type RedirectService interface {
 	List(context.Context, interface{}) ([]Redirect, error)
 	Count(context.Context, interface{}) (int, error)

--- a/scripttag.go
+++ b/scripttag.go
@@ -10,7 +10,7 @@ const scriptTagsBasePath = "script_tags"
 
 // ScriptTagService is an interface for interfacing with the ScriptTag endpoints
 // of the Shopify API.
-// See: https://help.shopify.com/api/reference/scripttag
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/scripttag
 type ScriptTagService interface {
 	List(context.Context, interface{}) ([]ScriptTag, error)
 	Count(context.Context, interface{}) (int, error)

--- a/shipping_zone.go
+++ b/shipping_zone.go
@@ -8,7 +8,7 @@ import (
 
 // ShippingZoneService is an interface for interfacing with the shipping zones endpoint
 // of the Shopify API.
-// See: https://help.shopify.com/api/reference/store-properties/shippingzone
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/shippingzone
 type ShippingZoneService interface {
 	List(context.Context) ([]ShippingZone, error)
 }

--- a/shop.go
+++ b/shop.go
@@ -10,7 +10,7 @@ const shopResourceName = ""
 
 // ShopService is an interface for interfacing with the shop endpoint of the
 // Shopify API.
-// See: https://help.shopify.com/api/reference/shop
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/shop
 type ShopService interface {
 	Get(ctx context.Context, options interface{}) (*Shop, error)
 

--- a/smartcollection.go
+++ b/smartcollection.go
@@ -13,7 +13,7 @@ const (
 
 // SmartCollectionService is an interface for interacting with the smart
 // collection endpoints of the Shopify API.
-// See https://help.shopify.com/api/reference/smartcollection
+// See https://shopify.dev/docs/api/admin-rest/latest/resources/smartcollection
 type SmartCollectionService interface {
 	List(context.Context, interface{}) ([]SmartCollection, error)
 	Count(context.Context, interface{}) (int, error)

--- a/storefrontaccesstoken.go
+++ b/storefrontaccesstoken.go
@@ -10,7 +10,7 @@ const storefrontAccessTokensBasePath = "storefront_access_tokens"
 
 // StorefrontAccessTokenService is an interface for interfacing with the storefront access
 // token endpoints of the Shopify API.
-// See: https://help.shopify.com/api/reference/access/storefrontaccesstoken
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/storefrontaccesstoken
 type StorefrontAccessTokenService interface {
 	List(context.Context, interface{}) ([]StorefrontAccessToken, error)
 	Create(context.Context, StorefrontAccessToken) (*StorefrontAccessToken, error)

--- a/theme.go
+++ b/theme.go
@@ -16,7 +16,7 @@ type ThemeListOptions struct {
 
 // ThemeService is an interface for interfacing with the themes endpoints
 // of the Shopify API.
-// See: https://help.shopify.com/api/reference/theme
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/theme
 type ThemeService interface {
 	List(context.Context, interface{}) ([]Theme, error)
 	Create(context.Context, Theme) (*Theme, error)

--- a/transaction.go
+++ b/transaction.go
@@ -7,7 +7,7 @@ import (
 
 // TransactionService is an interface for interfacing with the transactions endpoints of
 // the Shopify API.
-// See: https://help.shopify.com/api/reference/transaction
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/transaction
 type TransactionService interface {
 	List(context.Context, uint64, interface{}) ([]Transaction, error)
 	Count(context.Context, uint64, interface{}) (int, error)

--- a/usagecharge.go
+++ b/usagecharge.go
@@ -12,7 +12,7 @@ const usageChargesPath = "usage_charges"
 
 // UsageChargeService is an interface for interacting with the
 // UsageCharge endpoints of the Shopify API.
-// See https://help.shopify.com/en/api/reference/billing/usagecharge#endpoints
+// See https://shopify.dev/docs/api/admin-rest/latest/resources/usagecharge#endpoints
 type UsageChargeService interface {
 	Create(context.Context, uint64, UsageCharge) (*UsageCharge, error)
 	Get(context.Context, uint64, uint64, interface{}) (*UsageCharge, error)

--- a/variant.go
+++ b/variant.go
@@ -15,7 +15,7 @@ const (
 
 // VariantService is an interface for interacting with the variant endpoints
 // of the Shopify API.
-// See https://help.shopify.com/api/reference/product_variant
+// See https://shopify.dev/docs/api/admin-rest/latest/resources/product-variant
 type VariantService interface {
 	List(context.Context, uint64, interface{}) ([]Variant, error)
 	Count(context.Context, uint64, interface{}) (int, error)

--- a/webhook.go
+++ b/webhook.go
@@ -10,7 +10,7 @@ const webhooksBasePath = "webhooks"
 
 // WebhookService is an interface for interfacing with the webhook endpoints of
 // the Shopify API.
-// See: https://help.shopify.com/api/reference/webhook
+// See: https://shopify.dev/docs/api/admin-rest/latest/resources/webhook
 type WebhookService interface {
 	List(context.Context, interface{}) ([]Webhook, error)
 	Count(context.Context, interface{}) (int, error)


### PR DESCRIPTION
I replaced the broken links using the following one-liner. Also updated a typo for a link in variant.go

```bash
for f in `ls *.go`; do
perl -pi.bak -e 's!help.shopify.com/.*/(\w+)!shopify.dev/docs/api/admin-rest/latest/resources/$1!' $f
done
```
