### PR TITLE
Add TotalOutstanding field to Order struct

### DIFF
--- a/order.go
+++ b/order.go
@@ -304,6 +304,7 @@ type Order struct {
 	BillingAddress           *Address                `json:"billing_address,omitempty"`
 	ShippingAddress          *Address                `json:"shipping_address,omitempty"`
 	Currency                 string                  `json:"currency,omitempty"`
+	TotalOutstanding         *decimal.Decimal        `json:"total_outstanding,omitempty"`
 	TotalPrice               *decimal.Decimal        `json:"total_price,omitempty"`
 	TotalPriceSet            *AmountSet              `json:"total_price_set,omitempty"`
 	TotalShippingPriceSet    *AmountSet              `json:"total_shipping_price_set,omitempty"`


### PR DESCRIPTION
This PR adds the `total_outstanding` to the order struct.
https://shopify.dev/docs/api/admin-rest/2025-07/resources/order#resource-object


<img width="677" height="115" alt="Screenshot 2025-07-11 at 14 07 23" src="https://github.com/user-attachments/assets/e0a4ece6-7523-4358-b0e7-7691a0def871" />
