### PR TITLE
refactor: use http.NewRequestWithContext instead of http.NewRequest

### DIFF
--- a/goshopify.go
+++ b/goshopify.go
@@ -234,8 +234,6 @@ func (c *Client) NewRequest(ctx context.Context, method, relPath string, body, o
 		return nil, err
 	}
 
-	req = req.WithContext(ctx)
-
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("User-Agent", UserAgent)

--- a/goshopify.go
+++ b/goshopify.go
@@ -229,7 +229,7 @@ func (c *Client) NewRequest(ctx context.Context, method, relPath string, body, o
 		}
 	}
 
-	req, err := http.NewRequest(method, u.String(), bytes.NewBuffer(js))
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), bytes.NewBuffer(js))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I have the use case that I would like to use an OpenTelemetry instrumented http client so I can have trace information on the requests that go out to Shopify when using this client.

The current state of the library allows for the use of a custom http client, but since the request does not contain the context it leads to orphan span/traces. Using `http.NewRequestWithContext` fixes that issue.