### PR TITLE
fix: handle empty string decimal values in Shopify API responses

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -1,0 +1,39 @@
+package goshopify
+
+import (
+	"encoding/json"
+
+	"github.com/shopspring/decimal"
+)
+
+// FlexDecimal wraps *decimal.Decimal to handle Shopify API responses that may
+// return empty strings ("") for optional decimal fields. The standard
+// shopspring/decimal library cannot parse empty strings and returns an error.
+type FlexDecimal struct {
+	*decimal.Decimal
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// It handles null, empty strings, and valid decimal values.
+func (f *FlexDecimal) UnmarshalJSON(data []byte) error {
+	str := string(data)
+	if str == "null" || str == `""` || str == `''` {
+		f.Decimal = nil
+		return nil
+	}
+
+	var d decimal.Decimal
+	if err := json.Unmarshal(data, &d); err != nil {
+		return err
+	}
+	f.Decimal = &d
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (f FlexDecimal) MarshalJSON() ([]byte, error) {
+	if f.Decimal == nil {
+		return []byte("null"), nil
+	}
+	return json.Marshal(f.Decimal)
+}

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -1,0 +1,106 @@
+package goshopify
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestFlexDecimal_UnmarshalJSON_EmptyString(t *testing.T) {
+	var f FlexDecimal
+	err := json.Unmarshal([]byte(`""`), &f)
+	if err != nil {
+		t.Fatalf("expected no error for empty string, got: %v", err)
+	}
+	if f.Decimal != nil {
+		t.Fatalf("expected nil decimal for empty string, got: %v", f.Decimal)
+	}
+}
+
+func TestFlexDecimal_UnmarshalJSON_Null(t *testing.T) {
+	var f FlexDecimal
+	err := json.Unmarshal([]byte(`null`), &f)
+	if err != nil {
+		t.Fatalf("expected no error for null, got: %v", err)
+	}
+	if f.Decimal != nil {
+		t.Fatalf("expected nil decimal for null, got: %v", f.Decimal)
+	}
+}
+
+func TestFlexDecimal_UnmarshalJSON_ValidString(t *testing.T) {
+	var f FlexDecimal
+	err := json.Unmarshal([]byte(`"12.50"`), &f)
+	if err != nil {
+		t.Fatalf("expected no error for valid string, got: %v", err)
+	}
+	if f.Decimal == nil {
+		t.Fatal("expected non-nil decimal")
+	}
+	expected := decimal.NewFromFloat(12.50)
+	if !f.Decimal.Equal(expected) {
+		t.Fatalf("expected %s, got %s", expected, f.Decimal)
+	}
+}
+
+func TestFlexDecimal_UnmarshalJSON_ValidNumber(t *testing.T) {
+	var f FlexDecimal
+	err := json.Unmarshal([]byte(`0`), &f)
+	if err != nil {
+		t.Fatalf("expected no error for number, got: %v", err)
+	}
+	if f.Decimal == nil {
+		t.Fatal("expected non-nil decimal")
+	}
+	if !f.Decimal.Equal(decimal.Zero) {
+		t.Fatalf("expected 0, got %s", f.Decimal)
+	}
+}
+
+func TestFlexDecimal_MarshalJSON_Nil(t *testing.T) {
+	f := FlexDecimal{Decimal: nil}
+	data, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if string(data) != "null" {
+		t.Fatalf("expected null, got %s", string(data))
+	}
+}
+
+func TestFlexDecimal_MarshalJSON_Value(t *testing.T) {
+	d := decimal.NewFromFloat(9.99)
+	f := FlexDecimal{Decimal: &d}
+	data, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if string(data) != `"9.99"` {
+		t.Fatalf("expected \"9.99\", got %s", string(data))
+	}
+}
+
+func TestFlexDecimal_InStruct(t *testing.T) {
+	// Simulates the actual Shopify API response with empty flat_modifier
+	jsonData := `{
+		"id": 815531950300,
+		"carrier_service_id": 83880804572,
+		"shipping_zone_id": 392866726108,
+		"flat_modifier": "",
+		"percent_modifier": 0,
+		"service_filter": {"*": "+"}
+	}`
+
+	var provider CarrierShippingRateProvider
+	err := json.Unmarshal([]byte(jsonData), &provider)
+	if err != nil {
+		t.Fatalf("expected no error unmarshalling carrier provider with empty flat_modifier, got: %v", err)
+	}
+	if provider.FlatModifier.Decimal != nil {
+		t.Fatalf("expected nil flat_modifier, got: %v", provider.FlatModifier.Decimal)
+	}
+	if provider.PercentModifier.Decimal == nil {
+		t.Fatal("expected non-nil percent_modifier")
+	}
+}

--- a/shipping_zone.go
+++ b/shipping_zone.go
@@ -81,8 +81,8 @@ type CarrierShippingRateProvider struct {
 	Id               uint64            `json:"id,omitempty"`
 	CarrierServiceId uint64            `json:"carrier_service_id,omitempty"`
 	ShippingZoneId   uint64            `json:"shipping_zone_id,omitempty"`
-	FlatModifier     *decimal.Decimal  `json:"flat_modifier,omitempty"`
-	PercentModifier  *decimal.Decimal  `json:"percent_modifier,omitempty"`
+	FlatModifier     FlexDecimal       `json:"flat_modifier,omitempty"`
+	PercentModifier  FlexDecimal       `json:"percent_modifier,omitempty"`
 	ServiceFilter    map[string]string `json:"service_filter,omitempty"`
 }
 


### PR DESCRIPTION
Shopify API sometimes returns empty strings ("") for optional decimal fields like flat_modifier on CarrierShippingRateProvider. The shopspring/decimal library cannot parse empty strings, causing unmarshalling to fail.

Introduces FlexDecimal type that wraps *decimal.Decimal and gracefully handles null, empty strings, and valid decimal values.