### PR TITLE
feat(fulfillment_order): add Fulfillments (GET fulfillment_orders/{id}/fulfillments.json)

### DIFF
--- a/fulfillment_order.go
+++ b/fulfillment_order.go
@@ -12,6 +12,7 @@ import (
 type FulfillmentOrderService interface {
 	List(context.Context, uint64, interface{}) ([]FulfillmentOrder, error)
 	Get(context.Context, uint64, interface{}) (*FulfillmentOrder, error)
+	Fulfillments(context.Context, uint64) ([]Fulfillment, error)
 	Cancel(context.Context, uint64) (*FulfillmentOrder, error)
 	Close(context.Context, uint64, string) (*FulfillmentOrder, error)
 	Hold(context.Context, uint64, bool, FulfillmentOrderHoldReason, string) (*FulfillmentOrder, error)
@@ -179,6 +180,19 @@ func (s *FulfillmentOrderServiceOp) Get(ctx context.Context, fulfillmentId uint6
 	resource := new(FulfillmentOrderResource)
 	err := s.client.Get(ctx, path, resource, options)
 	return resource.FulfillmentOrder, err
+}
+
+// Fulfillments lists the fulfillments created for a specific fulfillment order.
+// Unlike FulfillmentService.List (scoped to an order, so it returns every fulfillment on a
+// possibly-split order), this is scoped to a single fulfillment order — the caller gets back
+// exactly the fulfillments that belong to that fulfillment order.
+// https://shopify.dev/docs/api/admin-rest/2023-01/resources/fulfillment#get-fulfillment-orders-fulfillment-order-id-fulfillments
+func (s *FulfillmentOrderServiceOp) Fulfillments(ctx context.Context, fulfillmentOrderId uint64) ([]Fulfillment, error) {
+	prefix := FulfillmentOrderPathPrefix("fulfillment_orders", fulfillmentOrderId)
+	path := fmt.Sprintf("%s/fulfillments.json", prefix)
+	resource := new(FulfillmentsResource)
+	err := s.client.Get(ctx, path, resource, nil)
+	return resource.Fulfillments, err
 }
 
 // Cancel cancels a fulfillment order

--- a/fulfillment_order_test.go
+++ b/fulfillment_order_test.go
@@ -65,6 +65,26 @@ func TestFulfillmentOrderGet(t *testing.T) {
 	}
 }
 
+func TestFulfillmentOrderFulfillments(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://fooshop.myshopify.com/%s/fulfillment_orders/255858046/fulfillments.json", client.pathPrefix),
+		httpmock.NewStringResponder(200, `{"fulfillments": [{"id":1},{"id":2}]}`))
+
+	fulfillmentOrderService := &FulfillmentOrderServiceOp{client: client}
+
+	fulfillments, err := fulfillmentOrderService.Fulfillments(context.Background(), 255858046)
+	if err != nil {
+		t.Errorf("FulfillmentOrder.Fulfillments returned error: %v", err)
+	}
+
+	expected := []Fulfillment{{Id: 1}, {Id: 2}}
+	if !reflect.DeepEqual(fulfillments, expected) {
+		t.Errorf("FulfillmentOrder.Fulfillments returned %+v, expected %+v", fulfillments, expected)
+	}
+}
+
 func TestFulfillmentOrderCancel(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
## What

Adds `FulfillmentOrderService.Fulfillments(ctx, fulfillmentOrderId)`, wrapping the Shopify Admin REST endpoint:

```
GET /admin/api/{version}/fulfillment_orders/{fulfillment_order_id}/fulfillments.json
```

https://shopify.dev/docs/api/admin-rest/2023-01/resources/fulfillment#get-fulfillment-orders-fulfillment-order-id-fulfillments

## Why

`FulfillmentService.List` is scoped to an **order**, so on an order that has been split into multiple fulfillment orders it returns *every* fulfillment on the order, with no way to tell which fulfillment belongs to which fulfillment order. There was no method for the fulfillment-order-scoped endpoint, which returns exactly the fulfillments created for a single fulfillment order.

This is needed to act on the correct fulfillment of a split order — e.g. posting a fulfillment event (tracking/shipment status) to the right fulfillment instead of all of them.

## Changes

- New `Fulfillments` method on `FulfillmentOrderService` / `FulfillmentOrderServiceOp`, returning `[]Fulfillment` via the existing `FulfillmentsResource` shape.
- Unit test `TestFulfillmentOrderFulfillments` mirroring the existing `FulfillmentOrder` test style (httpmock).

Additive only — no changes to existing methods or types. `go build ./...` and `go test ./...` pass.